### PR TITLE
Improve MASS precision for near-perfect correlations

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1576,16 +1576,43 @@ def _mass(Q, T, QT, μ_Q, σ_Q, M_T, Σ_T, Q_subseq_isconstant, T_subseq_isconst
 
     See Table II
 
-    Note that Q, T are not directly required to calculate D
-
     Note: Unlike the Matrix Profile I paper, here, M_T, Σ_T can be calculated
     once for all subsequences of T and passed in so the redundancy is removed
     """
     m = Q.shape[0]
+    k = M_T.shape[0]
+    distance_profile = np.empty(k, dtype=np.float64)
+    # When `1 - ρ` approaches machine precision, relative error from cancellation
+    # dominates. Recompute those rare distances from pointwise z-normalized
+    # differences once `1 - ρ` falls below `sqrt(eps)`.
+    threshold = 2.0 * m * np.sqrt(np.finfo(np.float64).eps)
 
-    return calculate_distance_profile(
-        m, QT, μ_Q, σ_Q, M_T, Σ_T, Q_subseq_isconstant, T_subseq_isconstant
-    )
+    for i in range(k):
+        D_squared = _calculate_squared_distance(
+            m,
+            QT[i],
+            μ_Q,
+            σ_Q,
+            M_T[i],
+            Σ_T[i],
+            Q_subseq_isconstant,
+            T_subseq_isconstant[i],
+        )
+
+        if (
+            D_squared < threshold
+            and not Q_subseq_isconstant
+            and not T_subseq_isconstant[i]
+        ):
+            D_squared = 0.0
+            for j in range(m):
+                Q_norm = (Q[j] - μ_Q) / σ_Q
+                T_norm = (T[i + j] - M_T[i]) / Σ_T[i]
+                D_squared += (Q_norm - T_norm) ** 2
+
+        distance_profile[i] = np.sqrt(D_squared)
+
+    return distance_profile
 
 
 @non_normalized(

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -74,6 +74,41 @@ def test_distace_profile():
         npt.assert_almost_equal(D_ref, D_comp)
 
 
+def test_mass_near_perfect_correlation():
+    # Regression data from #1171 contains two nearly affine-equivalent subsequences.
+    Q = np.array(
+        [
+            0.93406220661832629,
+            0.94732544958491172,
+            0.94288413821602846,
+        ]
+    )
+    T = np.array(
+        [
+            0.25089093970715337,
+            0.44046885357649379,
+            0.37698714499372254,
+        ]
+    )
+    m = Q.shape[0]
+
+    ref = naive.distance_profile(Q, T, m)
+    comp = core.mass(Q, T)
+
+    npt.assert_allclose(ref, comp, rtol=1e-12, atol=1e-12)
+
+
+def test_mass_near_perfect_correlation_rounded_to_zero():
+    Q = np.array([1.0, 2.0, 4.0])
+    T = np.array([-4.0, -0.99999999, 5.0])
+    m = Q.shape[0]
+
+    ref = naive.distance_profile(Q, T, m)
+    comp = core.mass(Q, T)
+
+    npt.assert_allclose(ref, comp, rtol=1e-12, atol=1e-12)
+
+
 def test_calculate_squared_distance():
     # This test function raises an error if the distance between a subsequence
     # and another does not satisfy the symmetry property.


### PR DESCRIPTION
## Summary

Fixes #1171.

MASS computes squared z-normalized distance as `2 * m * (1 - rho)`. For the nearly affine-equivalent length-3 subsequences in the reported seed, `1 - rho` is about `1.46e-13`, so cancellation in the sliding correlation formula amplifies ordinary float64 rounding. The motif indices are correct, but the resulting distance differs materially from a direct calculation.

This keeps the existing FFT/correlation path for ordinary candidates. When its squared distance is below `2 * m * sqrt(float64 epsilon)`—including values that incorrectly round to zero—`_mass` recomputes only that candidate from pointwise differences between the two z-normalized subsequences. Constant and non-finite handling stays on the existing path.

Two deterministic regressions cover:

- the nearly affine subsequences from the reported failure, where the old result differs from the 100-digit reference by roughly `3.7e-7`
- a non-identical pair whose correlation result incorrectly rounds to zero

Both regressions fail on clean `main` and pass with this change. The original `STUMPY_SEED=462698499` motif test also passes with JIT disabled and enabled without weakening its assertions.

## Performance

For `m=100` over 99,901 candidates with one threshold candidate, the compiled profile kernel measured a median 105.5 microseconds on the existing path and 132.5 microseconds with the stable fallback, a 27-microsecond delta. End-to-end `mass` timing remained within run-to-run noise in the same environment (8.058 ms on clean `main`, 7.951 ms with this change). The extra work is `O(c * m)`, where `c` is the number of extremely close candidates.

## Validation

Using the dependency versions from #1171 on Python 3.13.3:

- the focused core, precision, and motif suites pass with JIT disabled: 274 passed
- the same suites pass with JIT enabled: 272 passed, 2 expected GPU skips
- `./setup.sh dev && ./test.sh` passes both the compiled and coverage phases; CUDA simulation passes and coverage is 100% across 14,936 statements
- Black, isort, Flake8, docstring, package-import, fastmath-policy, and `git diff --check` checks pass
- Ray and pyFFTW are not installed; the repository harness reports and skips those optional paths

AI assistance was used for more than 15% of this change. I reviewed the numerical formulation, verified it against 100-digit Decimal references, mutation-checked both regressions against clean `main`, and ran the validation above.

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
