### PR TITLE
Add sphinx.ext.linkcode to link API docs directly to GitHub source

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,10 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import inspect
+import os
+import sys
+
 import stumpy
 
 # -- Project information -----------------------------------------------------
@@ -49,8 +53,8 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.linkcode",
     "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
     "sphinx_togglebutton",
     "numpydoc",
     "myst_nb",
@@ -243,3 +247,59 @@ myst_enable_extensions = [
 
 # Notebook cell execution timeout; defaults to 30.
 nb_execution_timeout = -1
+
+# -- Options for linkcode extension -------------------------------------
+
+
+def linkcode_resolve(domain, info):
+    """
+    Determine the GitHub URL corresponding to a Python object
+
+    Adapted from the `numpy` and `pandas` Sphinx `conf.py` files
+    """
+    if domain != "py":
+        return None
+
+    modname = info["module"]
+    fullname = info["fullname"]
+    if not modname:
+        return None
+
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError:
+            return None
+
+    obj = inspect.unwrap(obj)
+
+    try:
+        fn = inspect.getsourcefile(obj)
+    except TypeError:
+        fn = None
+    if not fn:
+        return None
+
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+    except (OSError, TypeError):
+        linespec = ""
+    else:
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
+
+    fn = os.path.relpath(fn, start=os.path.dirname(stumpy.__file__))
+
+    version = stumpy.__version__
+    # Fall back to `main` for dev/editable installs where `version` is not a
+    # proper release version (e.g., "dev" builds or an unresolvable install)
+    if "dev" in version or not version[:1].isdigit():
+        ref = "main"
+    else:
+        ref = f"v{version}"
+
+    return f"https://github.com/stumpy-dev/stumpy/blob/{ref}/stumpy/{fn}{linespec}"


### PR DESCRIPTION
Replaces sphinx.ext.viewcode (which copies source into the built docs) with sphinx.ext.linkcode, so each "[source]" link on readthedocs points straight to the corresponding line range on GitHub, following the same pattern used by numpy and pandas. Falls back to the `main` branch when stumpy.__version__ isn't a resolvable release version (e.g. editable installs).

Fixes #1081

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request
