### PR TITLE
Fixed #1175 Migrate tests/test_aamp.py to npt.assert_allclose

### DIFF
--- a/tests/test_aamp.py
+++ b/tests/test_aamp.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from stumpy import rng
+from stumpy import config, rng
 from stumpy.aamp import aamp
 
 test_data = [
@@ -160,7 +160,7 @@ def test_aamp_identical_subsequence_self_join():
     npt.assert_allclose(
         comp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
-        atol=1.5e-05,
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
@@ -168,7 +168,7 @@ def test_aamp_identical_subsequence_self_join():
     npt.assert_allclose(
         comp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
-        atol=1.5e-05,
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
 
@@ -186,7 +186,7 @@ def test_aamp_identical_subsequence_A_B_join():
     npt.assert_allclose(
         comp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
-        atol=1.5e-05,
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
@@ -194,7 +194,7 @@ def test_aamp_identical_subsequence_A_B_join():
     npt.assert_allclose(
         comp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
-        atol=1.5e-05,
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
     # Swap inputs
@@ -205,7 +205,7 @@ def test_aamp_identical_subsequence_A_B_join():
     npt.assert_allclose(
         comp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
-        atol=1.5e-05,
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
 

--- a/tests/test_aamp.py
+++ b/tests/test_aamp.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
-from stumpy import config, rng
+from stumpy import rng
 from stumpy.aamp import aamp
 
 test_data = [
@@ -36,13 +36,13 @@ def test_aamp_self_join(T_A, T_B):
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
         npt.assert_allclose(
-            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
         comp_mp = aamp(pd.Series(T_B), m, p=p)
         naive.replace_inf(comp_mp)
         npt.assert_allclose(
-            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
 
@@ -55,13 +55,13 @@ def test_aamp_A_B_join(T_A, T_B):
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
         npt.assert_allclose(
-            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
         comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, p=p)
         naive.replace_inf(comp_mp)
         npt.assert_allclose(
-            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
 
@@ -73,13 +73,13 @@ def test_aamp_constant_subsequence_self_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
 
@@ -92,13 +92,13 @@ def test_aamp_one_constant_subsequence_A_B_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
     # Swap inputs
@@ -107,7 +107,7 @@ def test_aamp_one_constant_subsequence_A_B_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
 
@@ -122,13 +122,13 @@ def test_aamp_two_constant_subsequences_A_B_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
     # Swap inputs
@@ -137,13 +137,13 @@ def test_aamp_two_constant_subsequences_A_B_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
 
@@ -158,17 +158,17 @@ def test_aamp_identical_subsequence_self_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64),
         comp_mp[:, 0].astype(np.float64),
-        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
+        ref_mp[:, 0].astype(np.float64),
+        atol=1.5e-05,
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64),
         comp_mp[:, 0].astype(np.float64),
-        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
+        ref_mp[:, 0].astype(np.float64),
+        atol=1.5e-05,
     )  # ignore indices
 
 
@@ -184,17 +184,17 @@ def test_aamp_identical_subsequence_A_B_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64),
         comp_mp[:, 0].astype(np.float64),
-        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
+        ref_mp[:, 0].astype(np.float64),
+        atol=1.5e-05,
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64),
         comp_mp[:, 0].astype(np.float64),
-        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
+        ref_mp[:, 0].astype(np.float64),
+        atol=1.5e-05,
     )  # ignore indices
 
     # Swap inputs
@@ -203,9 +203,9 @@ def test_aamp_identical_subsequence_A_B_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp[:, 0].astype(np.float64),
         comp_mp[:, 0].astype(np.float64),
-        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
+        ref_mp[:, 0].astype(np.float64),
+        atol=1.5e-05,
     )  # ignore indices
 
 
@@ -226,13 +226,13 @@ def test_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations):
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
         npt.assert_allclose(
-            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
         comp_mp = aamp(pd.Series(T_B_sub), m, ignore_trivial=True)
         naive.replace_inf(comp_mp)
         npt.assert_allclose(
-            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
 
@@ -260,7 +260,7 @@ def test_aamp_nan_inf_A_B_join(
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
             npt.assert_allclose(
-                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
             comp_mp = aamp(
@@ -268,7 +268,7 @@ def test_aamp_nan_inf_A_B_join(
             )
             naive.replace_inf(comp_mp)
             npt.assert_allclose(
-                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
 
@@ -282,7 +282,7 @@ def test_aamp_nan_zero_mean_self_join():
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
     npt.assert_allclose(
-        ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+        comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
     )
 
 
@@ -296,13 +296,13 @@ def test_aamp_self_join_KNN(T_A, T_B):
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
             npt.assert_allclose(
-                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
             comp_mp = aamp(pd.Series(T_B), m, p=p, k=k)
             naive.replace_inf(comp_mp)
             npt.assert_allclose(
-                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
 
@@ -316,7 +316,7 @@ def test_aamp_A_B_join_KNN(T_A, T_B):
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
             npt.assert_allclose(
-                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
             comp_mp = aamp(
@@ -324,5 +324,5 @@ def test_aamp_A_B_join_KNN(T_A, T_B):
             )
             naive.replace_inf(comp_mp)
             npt.assert_allclose(
-                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )

--- a/tests/test_aamp.py
+++ b/tests/test_aamp.py
@@ -35,11 +35,15 @@ def test_aamp_self_join(T_A, T_B):
         comp_mp = aamp(T_B, m, p=p)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        npt.assert_allclose(
+            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+        )
 
         comp_mp = aamp(pd.Series(T_B), m, p=p)
         naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        npt.assert_allclose(
+            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -50,11 +54,15 @@ def test_aamp_A_B_join(T_A, T_B):
         comp_mp = aamp(T_A, m, T_B, ignore_trivial=False, p=p)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        npt.assert_allclose(
+            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+        )
 
         comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, p=p)
         naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        npt.assert_allclose(
+            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 def test_aamp_constant_subsequence_self_join():
@@ -64,11 +72,15 @@ def test_aamp_constant_subsequence_self_join():
     comp_mp = aamp(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
 
 def test_aamp_one_constant_subsequence_A_B_join():
@@ -79,18 +91,24 @@ def test_aamp_one_constant_subsequence_A_B_join():
     comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
     # Swap inputs
     ref_mp = naive.aamp(T_B, m, T_B=T_A)
     comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
 
 def test_aamp_two_constant_subsequences_A_B_join():
@@ -103,22 +121,30 @@ def test_aamp_two_constant_subsequences_A_B_join():
     comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
     # Swap inputs
     ref_mp = naive.aamp(T_B, m, T_B=T_A)
     comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64), comp_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
 
 def test_aamp_identical_subsequence_self_join():
@@ -131,14 +157,18 @@ def test_aamp_identical_subsequence_self_join():
     comp_mp = aamp(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(
-        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64),
+        comp_mp[:, 0].astype(np.float64),
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(
-        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64),
+        comp_mp[:, 0].astype(np.float64),
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
 
@@ -153,14 +183,18 @@ def test_aamp_identical_subsequence_A_B_join():
     comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(
-        ref_mp[:, 0], comp_mp[:, 0], config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64),
+        comp_mp[:, 0].astype(np.float64),
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
     comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(
-        ref_mp[:, 0], comp_mp[:, 0], config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64),
+        comp_mp[:, 0].astype(np.float64),
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
     # Swap inputs
@@ -168,8 +202,10 @@ def test_aamp_identical_subsequence_A_B_join():
     comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(
-        ref_mp[:, 0], comp_mp[:, 0], config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        ref_mp[:, 0].astype(np.float64),
+        comp_mp[:, 0].astype(np.float64),
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
 
@@ -189,11 +225,15 @@ def test_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations):
         comp_mp = aamp(T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        npt.assert_allclose(
+            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+        )
 
         comp_mp = aamp(pd.Series(T_B_sub), m, ignore_trivial=True)
         naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        npt.assert_allclose(
+            ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -219,13 +259,17 @@ def test_aamp_nan_inf_A_B_join(
             comp_mp = aamp(T_A_sub, m, T_B_sub, ignore_trivial=False)
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            npt.assert_allclose(
+                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            )
 
             comp_mp = aamp(
                 pd.Series(T_A_sub), m, pd.Series(T_B_sub), ignore_trivial=False
             )
             naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            npt.assert_allclose(
+                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            )
 
 
 def test_aamp_nan_zero_mean_self_join():
@@ -237,7 +281,9 @@ def test_aamp_nan_zero_mean_self_join():
 
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp, comp_mp)
+    npt.assert_allclose(
+        ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+    )
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -249,11 +295,15 @@ def test_aamp_self_join_KNN(T_A, T_B):
             comp_mp = aamp(T_B, m, p=p, k=k)
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            npt.assert_allclose(
+                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            )
 
             comp_mp = aamp(pd.Series(T_B), m, p=p, k=k)
             naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            npt.assert_allclose(
+                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            )
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -265,10 +315,14 @@ def test_aamp_A_B_join_KNN(T_A, T_B):
             comp_mp = aamp(T_A, m, T_B, ignore_trivial=False, p=p, k=k)
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            npt.assert_allclose(
+                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            )
 
             comp_mp = aamp(
                 pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, p=p, k=k
             )
             naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            npt.assert_allclose(
+                ref_mp.astype(np.float64), comp_mp.astype(np.float64), atol=1.5e-07
+            )

--- a/tests/test_aamp.py
+++ b/tests/test_aamp.py
@@ -32,17 +32,17 @@ def test_aamp_self_join(T_A, T_B):
     m = 3
     for p in [1.0, 2.0, 3.0]:
         ref_mp = naive.aamp(T_B, m, p=p)
-        comp_mp = aamp(T_B, m, p=p)
+        cmp_mp = aamp(T_B, m, p=p)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
+        naive.replace_inf(cmp_mp)
         npt.assert_allclose(
-            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
-        comp_mp = aamp(pd.Series(T_B), m, p=p)
-        naive.replace_inf(comp_mp)
+        cmp_mp = aamp(pd.Series(T_B), m, p=p)
+        naive.replace_inf(cmp_mp)
         npt.assert_allclose(
-            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
 
@@ -51,17 +51,17 @@ def test_aamp_A_B_join(T_A, T_B):
     m = 3
     for p in [1.0, 2.0, 3.0]:
         ref_mp = naive.aamp(T_A, m, T_B=T_B, p=p)
-        comp_mp = aamp(T_A, m, T_B, ignore_trivial=False, p=p)
+        cmp_mp = aamp(T_A, m, T_B, ignore_trivial=False, p=p)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
+        naive.replace_inf(cmp_mp)
         npt.assert_allclose(
-            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
-        comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, p=p)
-        naive.replace_inf(comp_mp)
+        cmp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, p=p)
+        naive.replace_inf(cmp_mp)
         npt.assert_allclose(
-            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
 
@@ -69,17 +69,17 @@ def test_aamp_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     ref_mp = naive.aamp(T_A, m)
-    comp_mp = aamp(T_A, m, ignore_trivial=True)
+    cmp_mp = aamp(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
-    comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
-    naive.replace_inf(comp_mp)
+    cmp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
 
@@ -88,26 +88,26 @@ def test_aamp_one_constant_subsequence_A_B_join():
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     ref_mp = naive.aamp(T_A, m, T_B=T_B)
-    comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
+    cmp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
-    comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(comp_mp)
+    cmp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
     # Swap inputs
     ref_mp = naive.aamp(T_B, m, T_B=T_A)
-    comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
+    cmp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
 
@@ -118,32 +118,32 @@ def test_aamp_two_constant_subsequences_A_B_join():
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     ref_mp = naive.aamp(T_A, m, T_B=T_B)
-    comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
+    cmp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
-    comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(comp_mp)
+    cmp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
     # Swap inputs
     ref_mp = naive.aamp(T_B, m, T_B=T_A)
-    comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
+    cmp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
-    comp_mp = aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    naive.replace_inf(comp_mp)
+    cmp_mp = aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
     )  # ignore indices
 
 
@@ -154,19 +154,19 @@ def test_aamp_identical_subsequence_self_join():
     T_A[11 : 11 + identical.shape[0]] = identical
     m = 3
     ref_mp = naive.aamp(T_A, m)
-    comp_mp = aamp(T_A, m, ignore_trivial=True)
+    cmp_mp = aamp(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64),
+        cmp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
         atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
-    comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
-    naive.replace_inf(comp_mp)
+    cmp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64),
+        cmp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
         atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
@@ -180,30 +180,30 @@ def test_aamp_identical_subsequence_A_B_join():
     T_B[11 : 11 + identical.shape[0]] = identical
     m = 3
     ref_mp = naive.aamp(T_A, m, T_B=T_B)
-    comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
+    cmp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64),
+        cmp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
         atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
-    comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(comp_mp)
+    cmp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64),
+        cmp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
         atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
     # Swap inputs
     ref_mp = naive.aamp(T_B, m, T_B=T_A)
-    comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
+    cmp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp[:, 0].astype(np.float64),
+        cmp_mp[:, 0].astype(np.float64),
         ref_mp[:, 0].astype(np.float64),
         atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
@@ -222,17 +222,17 @@ def test_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations):
         T_B_sub[substitution_location_B] = substitute_B
 
         ref_mp = naive.aamp(T_B_sub, m)
-        comp_mp = aamp(T_B_sub, m, ignore_trivial=True)
+        cmp_mp = aamp(T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
+        naive.replace_inf(cmp_mp)
         npt.assert_allclose(
-            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
-        comp_mp = aamp(pd.Series(T_B_sub), m, ignore_trivial=True)
-        naive.replace_inf(comp_mp)
+        cmp_mp = aamp(pd.Series(T_B_sub), m, ignore_trivial=True)
+        naive.replace_inf(cmp_mp)
         npt.assert_allclose(
-            comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
         )
 
 
@@ -256,19 +256,19 @@ def test_aamp_nan_inf_A_B_join(
             T_B_sub[substitution_location_B] = substitute_B
 
             ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-            comp_mp = aamp(T_A_sub, m, T_B_sub, ignore_trivial=False)
+            cmp_mp = aamp(T_A_sub, m, T_B_sub, ignore_trivial=False)
             naive.replace_inf(ref_mp)
-            naive.replace_inf(comp_mp)
+            naive.replace_inf(cmp_mp)
             npt.assert_allclose(
-                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
-            comp_mp = aamp(
+            cmp_mp = aamp(
                 pd.Series(T_A_sub), m, pd.Series(T_B_sub), ignore_trivial=False
             )
-            naive.replace_inf(comp_mp)
+            naive.replace_inf(cmp_mp)
             npt.assert_allclose(
-                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
 
@@ -277,12 +277,12 @@ def test_aamp_nan_zero_mean_self_join():
     m = 3
 
     ref_mp = naive.aamp(T, m)
-    comp_mp = aamp(T, m, ignore_trivial=True)
+    cmp_mp = aamp(T, m, ignore_trivial=True)
 
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
+    naive.replace_inf(cmp_mp)
     npt.assert_allclose(
-        comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
     )
 
 
@@ -292,17 +292,17 @@ def test_aamp_self_join_KNN(T_A, T_B):
     for k in range(2, 4):
         for p in [1.0, 2.0, 3.0]:
             ref_mp = naive.aamp(T_B, m, p=p, k=k)
-            comp_mp = aamp(T_B, m, p=p, k=k)
+            cmp_mp = aamp(T_B, m, p=p, k=k)
             naive.replace_inf(ref_mp)
-            naive.replace_inf(comp_mp)
+            naive.replace_inf(cmp_mp)
             npt.assert_allclose(
-                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
-            comp_mp = aamp(pd.Series(T_B), m, p=p, k=k)
-            naive.replace_inf(comp_mp)
+            cmp_mp = aamp(pd.Series(T_B), m, p=p, k=k)
+            naive.replace_inf(cmp_mp)
             npt.assert_allclose(
-                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
 
@@ -312,17 +312,17 @@ def test_aamp_A_B_join_KNN(T_A, T_B):
     for k in range(2, 4):
         for p in [1.0, 2.0, 3.0]:
             ref_mp = naive.aamp(T_A, m, T_B=T_B, p=p, k=k)
-            comp_mp = aamp(T_A, m, T_B, ignore_trivial=False, p=p, k=k)
+            cmp_mp = aamp(T_A, m, T_B, ignore_trivial=False, p=p, k=k)
             naive.replace_inf(ref_mp)
-            naive.replace_inf(comp_mp)
+            naive.replace_inf(cmp_mp)
             npt.assert_allclose(
-                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )
 
-            comp_mp = aamp(
+            cmp_mp = aamp(
                 pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, p=p, k=k
             )
-            naive.replace_inf(comp_mp)
+            naive.replace_inf(cmp_mp)
             npt.assert_allclose(
-                comp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
             )


### PR DESCRIPTION
Fixed #1175

Per review feedback, split into one PR per test file - this one covers `tests/test_aamp.py` only. Will open the next file's PR once this one merges.

`assert_almost_equal` only checks a fixed absolute tolerance and NumPy's docs recommend `assert_allclose` instead. Every comparison in this file is against `ref_mp`/`cmp_mp` (or a column slice of it), which combine a float distance column with int index columns and so come back `dtype=object` - `np.isclose` can't handle that directly. Cast both sides to `float64` before comparing instead of leaving these on the deprecated API, since the values are always numeric so the cast is exact. All 27 call sites in this file are now on `assert_allclose`, none left behind. `rtol` is left at its default rather than pinned to `0`.

## To Do List

Standing checklist from @seanlaw for this migration, applies to every file in the split - status below is for `test_aamp.py`:

- [x] Each test file correctly replaces all uses of `npt.assert_almost_equal` with its equivalent `npt.assert_allclose`
- [x] When `rtol=0` for `npt.assert_allclose`, simply omit this parameter and value since this is the default
- [x] Ensure that `npt.assert_allclose(actual, desired)` always has the stumpy computed value as `actual` and the naive computation as `desired`
- [x] Use `atol=1.5e-07` rather than `atol=1.5*10**-07`
- [ ] Eventually, replace the ugly `1.5*10**-config.STUMPY_TEST_PRECISION` with `config.STUMPY_TEST_PRECISION = 1.5e-07` (in `config.py`) - tracked as a follow-up, not part of this per-file migration
- [x] Use `cmp` instead of `comp` for the computed/performant value, so it's the same length as `ref` (`comp_mp` -> `cmp_mp`)

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
