### PR TITLE
Fixed #1175 Migrate tests/test_aamp_motifs.py to npt.assert_allclose

### DIFF
--- a/tests/test_aamp_motifs.py
+++ b/tests/test_aamp_motifs.py
@@ -51,12 +51,12 @@ def test_aamp_motifs_one_motif():
     m = 3
     max_motifs = 1
 
-    left_indices = [[0, 5]]
-    left_profile_values = [[0.0, 0.0]]
+    ref_indices = [[0, 5]]
+    ref_profile_values = [[0.0, 0.0]]
 
     for p in [1.0, 2.0, 3.0]:
         mp = naive.aamp(T, m, p=p)
-        right_distance_values, right_indices = aamp_motifs(
+        cmp_distance_values, cmp_indices = aamp_motifs(
             T,
             mp[:, 0],
             max_motifs=max_motifs,
@@ -65,8 +65,8 @@ def test_aamp_motifs_one_motif():
             p=p,
         )
 
-        npt.assert_array_equal(left_indices, right_indices)
-        npt.assert_allclose(right_distance_values, left_profile_values, atol=1.5e-04)
+        npt.assert_array_equal(cmp_indices, ref_indices)
+        npt.assert_allclose(cmp_distance_values, ref_profile_values, atol=1.5e-04)
 
 
 def test_aamp_motifs_two_motifs():
@@ -105,8 +105,8 @@ def test_aamp_motifs_two_motifs():
 
         mp = naive.aamp(T, m)
 
-        # left_indices = [[70, 170], [10, 210]]
-        left_profile_values = [
+        # ref_indices = [[70, 170], [10, 210]]
+        ref_profile_values = [
             [0.0, 0.0],
             [
                 0.0,
@@ -114,7 +114,7 @@ def test_aamp_motifs_two_motifs():
             ],
         ]
 
-        right_distance_values, right_indices = aamp_motifs(
+        cmp_distance_values, cmp_indices = aamp_motifs(
             T,
             mp[:, 0],
             max_motifs=max_motifs,
@@ -124,7 +124,7 @@ def test_aamp_motifs_two_motifs():
 
         # We ignore indices because of sorting ambiguities for equal distances.
         # As long as the distances are correct, the indices will be too.
-        npt.assert_allclose(right_distance_values, left_profile_values, atol=1.5e-06)
+        npt.assert_allclose(cmp_distance_values, ref_profile_values, atol=1.5e-06)
 
 
 def test_aamp_naive_match_exact():
@@ -135,8 +135,8 @@ def test_aamp_naive_match_exact():
     excl_zone = int(np.ceil(m / 4))
 
     for p in [1.0, 2.0, 3.0]:
-        left = [[0, 0], [0, 5]]
-        right = list(
+        ref = [[0, 0], [0, 5]]
+        cmp = list(
             naive_aamp_match(
                 Q,
                 T,
@@ -147,11 +147,11 @@ def test_aamp_naive_match_exact():
         )
         # To avoid sorting errors we first sort based on distance and then based on
         # indices
-        right.sort(key=lambda x: (x[1], x[0]))
+        cmp.sort(key=lambda x: (x[1], x[0]))
 
         npt.assert_allclose(
-            np.array(right).astype(np.float64),
-            np.array(left).astype(np.float64),
+            np.array(cmp).astype(np.float64),
+            np.array(ref).astype(np.float64),
             atol=1.5e-07,
         )
 
@@ -170,11 +170,11 @@ def test_aamp_naive_match_exclusion_zone():
     excl_zone = m
 
     for p in [1.0, 2.0, 3.0]:
-        left = [
+        ref = [
             [0, 3],
             [naive.distance(Q, T[7 : 7 + m], p=p), 7],
         ]
-        right = list(
+        cmp = list(
             naive_aamp_match(
                 Q,
                 T,
@@ -185,11 +185,11 @@ def test_aamp_naive_match_exclusion_zone():
         )
         # To avoid sorting errors we first sort based on distance and then based on
         # indices
-        right.sort(key=lambda x: (x[0], x[1]))
+        cmp.sort(key=lambda x: (x[0], x[1]))
 
         npt.assert_allclose(
-            np.array(right).astype(np.float64),
-            np.array(left).astype(np.float64),
+            np.array(cmp).astype(np.float64),
+            np.array(ref).astype(np.float64),
             atol=1.5e-07,
         )
 
@@ -201,7 +201,7 @@ def test_aamp_match(Q, T):
     max_distance = 0.3
 
     for p in [1.0, 2.0, 3.0]:
-        left = naive_aamp_match(
+        ref = naive_aamp_match(
             Q,
             T,
             p=p,
@@ -209,7 +209,7 @@ def test_aamp_match(Q, T):
             max_distance=max_distance,
         )
 
-        right = aamp_match(
+        cmp = aamp_match(
             Q,
             T,
             p=p,
@@ -218,7 +218,7 @@ def test_aamp_match(Q, T):
         )
 
         npt.assert_allclose(
-            right.astype(np.float64), left.astype(np.float64), atol=1.5e-07
+            cmp.astype(np.float64), ref.astype(np.float64), atol=1.5e-07
         )
 
 
@@ -230,7 +230,7 @@ def test_aamp_match_T_subseq_isfinite(Q, T):
     T, T_subseq_isfinite = core.preprocess_non_normalized(T, len(Q))
 
     for p in [1.0, 2.0, 3.0]:
-        left = naive_aamp_match(
+        ref = naive_aamp_match(
             Q,
             T,
             p=p,
@@ -238,7 +238,7 @@ def test_aamp_match_T_subseq_isfinite(Q, T):
             max_distance=max_distance,
         )
 
-        right = aamp_match(
+        cmp = aamp_match(
             Q,
             T,
             T_subseq_isfinite,
@@ -248,7 +248,7 @@ def test_aamp_match_T_subseq_isfinite(Q, T):
         )
 
         npt.assert_allclose(
-            right.astype(np.float64), left.astype(np.float64), atol=1.5e-07
+            cmp.astype(np.float64), ref.astype(np.float64), atol=1.5e-07
         )
 
 

--- a/tests/test_aamp_motifs.py
+++ b/tests/test_aamp_motifs.py
@@ -66,7 +66,7 @@ def test_aamp_motifs_one_motif():
         )
 
         npt.assert_array_equal(left_indices, right_indices)
-        npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=4)
+        npt.assert_allclose(right_distance_values, left_profile_values, atol=1.5e-04)
 
 
 def test_aamp_motifs_two_motifs():
@@ -124,7 +124,7 @@ def test_aamp_motifs_two_motifs():
 
         # We ignore indices because of sorting ambiguities for equal distances.
         # As long as the distances are correct, the indices will be too.
-        npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=6)
+        npt.assert_allclose(right_distance_values, left_profile_values, atol=1.5e-06)
 
 
 def test_aamp_naive_match_exact():
@@ -149,7 +149,11 @@ def test_aamp_naive_match_exact():
         # indices
         right.sort(key=lambda x: (x[1], x[0]))
 
-        npt.assert_almost_equal(left, right)
+        npt.assert_allclose(
+            np.array(right).astype(np.float64),
+            np.array(left).astype(np.float64),
+            atol=1.5e-07,
+        )
 
 
 def test_aamp_naive_match_exclusion_zone():
@@ -183,7 +187,11 @@ def test_aamp_naive_match_exclusion_zone():
         # indices
         right.sort(key=lambda x: (x[0], x[1]))
 
-        npt.assert_almost_equal(left, right)
+        npt.assert_allclose(
+            np.array(right).astype(np.float64),
+            np.array(left).astype(np.float64),
+            atol=1.5e-07,
+        )
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -209,7 +217,9 @@ def test_aamp_match(Q, T):
             max_distance=max_distance,
         )
 
-        npt.assert_almost_equal(left, right)
+        npt.assert_allclose(
+            right.astype(np.float64), left.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -237,7 +247,9 @@ def test_aamp_match_T_subseq_isfinite(Q, T):
             max_distance=max_distance,
         )
 
-        npt.assert_almost_equal(left, right)
+        npt.assert_allclose(
+            right.astype(np.float64), left.astype(np.float64), atol=1.5e-07
+        )
 
 
 def test_aamp_match_query_idx():
@@ -248,7 +260,7 @@ def test_aamp_match_query_idx():
 
     # `mass_absolute` zeroes the self-match distance when told where `Q` lives.
     D = core.mass_absolute(Q, T, query_idx=query_idx)
-    npt.assert_almost_equal(D[query_idx], 0.0)
+    npt.assert_allclose(D[query_idx], 0.0, atol=1.5e-07)
 
     # A `Q` that is not the subsequence at `query_idx` must still return the
     # self-match first, and must warn, exactly as `stumpy.match` does.
@@ -256,4 +268,4 @@ def test_aamp_match_query_idx():
         out = aamp_match(Q + 0.5, T, query_idx=query_idx, max_distance=1.0)
 
     assert out[0, 1] == query_idx
-    npt.assert_almost_equal(out[0, 0], 0.0)
+    npt.assert_allclose(out[0, 0], 0.0, atol=1.5e-07)


### PR DESCRIPTION
Fixed #1175

Continuing the file-by-file split from #1178 — this one covers `tests/test_aamp_motifs.py`. Will open the next file's PR once this one merges.

`assert_almost_equal` only checks a fixed absolute tolerance and NumPy's docs recommend `assert_allclose` instead. Eight call sites in this file, three different wrinkles:

- Two calls compare the `left`/`right` argument order backwards relative to the `actual, desired` convention (`right`/`out` is always the stumpy-computed value in this file, `left` is either a hand-derived expected value or the naive helper's output) — flipped both.
- Four calls compare against `aamp_match`/`naive_aamp_match` output, which mixes a float distance with an int index and so comes back `dtype=object` — same issue as `test_aamp.py`, same fix: cast both sides to `float64` before comparing, since the values are always numeric.
- The original `decimal=` values weren't all the same (`4`, `6`, and the implicit default of `7`), so I kept each site's original tolerance rather than flattening everything to `1.5e-07` — translated `decimal=4`/`decimal=6` to `atol=1.5e-04`/`atol=1.5e-06` respectively, and the two unlabeled ones to `atol=1.5e-07` per the usual convention.

Also ran the file across five random seeds (JIT disabled, CUDA simulated, matching `test.sh coverage`) since `test_data` in this file draws from unseeded `rng.RNG` — wanted to make sure the tolerances hold up beyond just the one seed I happened to run with.

**Update:** per review, also renamed every `left`/`right` variable to `ref_`/`cmp_` (naive output = `ref`, stumpy-computed output = `cmp`), and flipped the `npt.assert_array_equal` argument order to match the same `actual, desired` convention as `assert_allclose`.

## To Do List

Standing checklist from @seanlaw for this migration, applies to every file in the split - status below is for `test_aamp_motifs.py`:

- [x] Each test file correctly replaces all uses of `npt.assert_almost_equal` with its equivalent `npt.assert_allclose`
- [x] When `rtol=0` for `npt.assert_allclose`, simply omit this parameter and value since this is the default
- [x] Ensure that `npt.assert_allclose(actual, desired)` always has the stumpy computed value as `actual` and the naive computation as `desired`
- [x] Use `atol=1.5e-07` rather than `atol=1.5*10**-07`
- [ ] Eventually, replace the ugly `1.5*10**-config.STUMPY_TEST_PRECISION` with `config.STUMPY_TEST_PRECISION = 1.5e-07` (in `config.py`) - tracked as a follow-up, not part of this per-file migration
- [x] Use `cmp` instead of `comp` - n/a for this file, it never used `comp` naming to begin with
- [x] Rename naive outputs to `ref_` and stumpy-computed outputs to `cmp_` (applies to `npt.assert_array_equal` too, not just `npt.assert_allclose`) - this file originally used `left`/`right`, all renamed

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
