### PR TITLE
Fixed #1175 Migrate tests/test_aamp_ostinato.py to npt.assert_allclose

### DIFF
--- a/tests/test_aamp_ostinato.py
+++ b/tests/test_aamp_ostinato.py
@@ -31,11 +31,11 @@ def test_random_ostinato(runs):
     Ts = [rng.RNG.rand(n) for n in [64, 128, 256]]
 
     ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m)
-    comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinato(Ts, m)
+    cmp_radius, cmp_Ts_idx, cmp_subseq_idx = aamp_ostinato(Ts, m)
 
-    npt.assert_almost_equal(ref_radius, comp_radius)
-    npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-    npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+    npt.assert_allclose(cmp_radius, ref_radius, atol=1.5e-07)
+    npt.assert_allclose(cmp_Ts_idx, ref_Ts_idx, atol=1.5e-07)
+    npt.assert_allclose(cmp_subseq_idx, ref_subseq_idx, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("seed", [41, 88, 290, 292, 310, 328, 538, 556, 563, 570])
@@ -47,11 +47,11 @@ def test_deterministic_ostinato(seed):
 
         for p in [1.0, 2.0, 3.0]:
             ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m, p=p)
-            comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinato(Ts, m, p=p)
+            cmp_radius, cmp_Ts_idx, cmp_subseq_idx = aamp_ostinato(Ts, m, p=p)
 
-            npt.assert_almost_equal(ref_radius, comp_radius)
-            npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-            npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+            npt.assert_allclose(cmp_radius, ref_radius, atol=1.5e-07)
+            npt.assert_allclose(cmp_Ts_idx, ref_Ts_idx, atol=1.5e-07)
+            npt.assert_allclose(cmp_subseq_idx, ref_subseq_idx, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("runs", range(25))
@@ -61,11 +61,11 @@ def test_random_ostinatoed(runs, dask_cluster):
         Ts = [rng.RNG.rand(n) for n in [64, 128, 256]]
 
         ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m)
-        comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinatoed(dask_client, Ts, m)
+        cmp_radius, cmp_Ts_idx, cmp_subseq_idx = aamp_ostinatoed(dask_client, Ts, m)
 
-        npt.assert_almost_equal(ref_radius, comp_radius)
-        npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-        npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+        npt.assert_allclose(cmp_radius, ref_radius, atol=1.5e-07)
+        npt.assert_allclose(cmp_Ts_idx, ref_Ts_idx, atol=1.5e-07)
+        npt.assert_allclose(cmp_subseq_idx, ref_subseq_idx, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("seed", [41, 88, 290, 292, 310, 328, 538, 556, 563, 570])
@@ -78,13 +78,13 @@ def test_deterministic_ostinatoed(seed, dask_cluster):
 
             for p in [1.0, 2.0, 3.0]:
                 ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m, p=p)
-                comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinatoed(
+                cmp_radius, cmp_Ts_idx, cmp_subseq_idx = aamp_ostinatoed(
                     dask_client, Ts, m, p=p
                 )
 
-                npt.assert_almost_equal(ref_radius, comp_radius)
-                npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-                npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+                npt.assert_allclose(cmp_radius, ref_radius, atol=1.5e-07)
+                npt.assert_allclose(cmp_Ts_idx, ref_Ts_idx, atol=1.5e-07)
+                npt.assert_allclose(cmp_subseq_idx, ref_subseq_idx, atol=1.5e-07)
 
 
 def test_input_not_overwritten_ostinato():
@@ -101,8 +101,10 @@ def test_input_not_overwritten_ostinato():
     aamp_ostinato(Ts_input, m)
     for i in range(len(Ts)):
         T_ref = Ts[i]
-        T_comp = Ts_input[i]
-        npt.assert_almost_equal(T_ref[np.isfinite(T_ref)], T_comp[np.isfinite(T_comp)])
+        T_cmp = Ts_input[i]
+        npt.assert_allclose(
+            T_cmp[np.isfinite(T_cmp)], T_ref[np.isfinite(T_ref)], atol=1.5e-07
+        )
 
 
 def test_extract_several_consensus_ostinato():
@@ -110,18 +112,18 @@ def test_extract_several_consensus_ostinato():
     # does not tamper with the original data.
     Ts = [rng.RNG.rand(n) for n in [256, 512, 1024]]
     Ts_ref = [T.copy() for T in Ts]
-    Ts_comp = [T.copy() for T in Ts]
+    Ts_cmp = [T.copy() for T in Ts]
 
     m = 20
 
     k = 5  # Get the first `k` consensus motifs
     for _ in range(k):
-        # Find consensus motif and its NN in each time series in Ts_comp
-        # Remove them from Ts_comp as well as Ts_ref, and assert that the
+        # Find consensus motif and its NN in each time series in Ts_cmp
+        # Remove them from Ts_cmp as well as Ts_ref, and assert that the
         # two time series are the same
-        radius, Ts_idx, subseq_idx = aamp_ostinato(Ts_comp, m)
-        consensus_motif = Ts_comp[Ts_idx][subseq_idx : subseq_idx + m].copy()
-        for i in range(len(Ts_comp)):
+        radius, Ts_idx, subseq_idx = aamp_ostinato(Ts_cmp, m)
+        consensus_motif = Ts_cmp[Ts_idx][subseq_idx : subseq_idx + m].copy()
+        for i in range(len(Ts_cmp)):
             if i == Ts_idx:
                 query_idx = subseq_idx
             else:
@@ -129,14 +131,16 @@ def test_extract_several_consensus_ostinato():
 
             idx = np.argmin(
                 core.mass(
-                    consensus_motif, Ts_comp[i], normalize=False, query_idx=query_idx
+                    consensus_motif, Ts_cmp[i], normalize=False, query_idx=query_idx
                 )
             )
-            Ts_comp[i][idx : idx + m] = np.nan
+            Ts_cmp[i][idx : idx + m] = np.nan
             Ts_ref[i][idx : idx + m] = np.nan
 
-            npt.assert_almost_equal(
-                Ts_ref[i][np.isfinite(Ts_ref[i])], Ts_comp[i][np.isfinite(Ts_comp[i])]
+            npt.assert_allclose(
+                Ts_cmp[i][np.isfinite(Ts_cmp[i])],
+                Ts_ref[i][np.isfinite(Ts_ref[i])],
+                atol=1.5e-07,
             )
 
 
@@ -155,9 +159,9 @@ def test_input_not_overwritten_ostinatoed(dask_cluster):
         aamp_ostinatoed(dask_client, Ts_input, m)
         for i in range(len(Ts)):
             T_ref = Ts[i]
-            T_comp = Ts_input[i]
-            npt.assert_almost_equal(
-                T_ref[np.isfinite(T_ref)], T_comp[np.isfinite(T_comp)]
+            T_cmp = Ts_input[i]
+            npt.assert_allclose(
+                T_cmp[np.isfinite(T_cmp)], T_ref[np.isfinite(T_ref)], atol=1.5e-07
             )
 
 
@@ -166,19 +170,19 @@ def test_extract_several_consensus_ostinatoed(dask_cluster):
     # does not tamper with the original data.
     Ts = [rng.RNG.rand(n) for n in [256, 512, 1024]]
     Ts_ref = [T.copy() for T in Ts]
-    Ts_comp = [T.copy() for T in Ts]
+    Ts_cmp = [T.copy() for T in Ts]
 
     m = 20
 
     with Client(dask_cluster) as dask_client:
         k = 5  # Get the first `k` consensus motifs
         for _ in range(k):
-            # Find consensus motif and its NN in each time series in Ts_comp
-            # Remove them from Ts_comp as well as Ts_ref, and assert that the
+            # Find consensus motif and its NN in each time series in Ts_cmp
+            # Remove them from Ts_cmp as well as Ts_ref, and assert that the
             # two time series are the same
-            radius, Ts_idx, subseq_idx = aamp_ostinatoed(dask_client, Ts_comp, m)
-            consensus_motif = Ts_comp[Ts_idx][subseq_idx : subseq_idx + m].copy()
-            for i in range(len(Ts_comp)):
+            radius, Ts_idx, subseq_idx = aamp_ostinatoed(dask_client, Ts_cmp, m)
+            consensus_motif = Ts_cmp[Ts_idx][subseq_idx : subseq_idx + m].copy()
+            for i in range(len(Ts_cmp)):
                 if i == Ts_idx:
                     query_idx = subseq_idx
                 else:
@@ -187,15 +191,16 @@ def test_extract_several_consensus_ostinatoed(dask_cluster):
                 idx = np.argmin(
                     core.mass(
                         consensus_motif,
-                        Ts_comp[i],
+                        Ts_cmp[i],
                         normalize=False,
                         query_idx=query_idx,
                     )
                 )
-                Ts_comp[i][idx : idx + m] = np.nan
+                Ts_cmp[i][idx : idx + m] = np.nan
                 Ts_ref[i][idx : idx + m] = np.nan
 
-                npt.assert_almost_equal(
+                npt.assert_allclose(
+                    Ts_cmp[i][np.isfinite(Ts_cmp[i])],
                     Ts_ref[i][np.isfinite(Ts_ref[i])],
-                    Ts_comp[i][np.isfinite(Ts_comp[i])],
+                    atol=1.5e-07,
                 )


### PR DESCRIPTION
Fixed #1175

Continuing the file-by-file split from #1178/#1181 — this one covers `tests/test_aamp_ostinato.py`. Will open the next file's PR once this one merges.

`assert_almost_equal` only checks a fixed absolute tolerance and NumPy's docs recommend `assert_allclose` instead. 16 call sites in this file, all following the same two fixes established in the previous two PRs:

- All calls had the naive/stumpy argument order backwards (`ref_x, cmp_x` instead of `cmp_x, ref_x`) — flipped every one to put the stumpy-computed value first.
- The file already used `ref_`/`comp_` naming (radius/Ts_idx/subseq_idx, plus `T_comp`/`Ts_comp` in the overwrite-safety tests) — renamed every `comp` to `cmp` per the standing convention.

Checked the actual return dtypes from `aamp_ostinato` before touching anything (`radius` is `float64`, `Ts_idx`/`subseq_idx` are plain int/`int64`) — none of them come back `dtype=object` the way the mixed distance/index arrays in `test_aamp.py`/`test_aamp_motifs.py` did, so no `.astype(np.float64)` casting was needed here. None of the original calls specified `decimal=`, so every site uses the default `atol=1.5e-07`.

Ran the full file twice locally (normal mode and JIT-disabled/CUDA-simulated, matching `test.sh coverage`) — 74/74 passing both times. The dask-backed tests (`test_random_ostinatoed`, `test_deterministic_ostinatoed`, etc.) spin up a real `LocalCluster`, so this one takes noticeably longer than the previous two files (~30-50s locally).

## To Do List

Standing checklist from @seanlaw for this migration, applies to every file in the split - status below is for `test_aamp_ostinato.py`:

- [x] Each test file correctly replaces all uses of `npt.assert_almost_equal` with its equivalent `npt.assert_allclose`
- [x] When `rtol=0` for `npt.assert_allclose`, simply omit this parameter and value since this is the default
- [x] Ensure that `npt.assert_allclose(actual, desired)` always has the stumpy computed value as `actual` and the naive computation as `desired`
- [x] Use `atol=1.5e-07` rather than `atol=1.5*10**-07`
- [ ] Eventually, replace the ugly `1.5*10**-config.STUMPY_TEST_PRECISION` with `config.STUMPY_TEST_PRECISION = 1.5e-07` (in `config.py`) - tracked as a follow-up, not part of this per-file migration
- [x] Use `cmp` instead of `comp` - this file used `comp_radius`/`comp_Ts_idx`/`comp_subseq_idx`/`T_comp`/`Ts_comp`, all renamed
- [x] Rename naive outputs to `ref_` and stumpy-computed outputs to `cmp_` (applies to `npt.assert_array_equal` too) - this file already used `ref_`/`comp_`, no `assert_array_equal` calls present

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
