### PR TITLE
Fixed #1175 Migrate tests/test_aamp_stimp.py to npt.assert_allclose

### DIFF
--- a/tests/test_aamp_stimp.py
+++ b/tests/test_aamp_stimp.py
@@ -68,7 +68,7 @@ def test_aamp_stimp_1_percent(T):
     naive.replace_inf(ref_PAN)
     naive.replace_inf(cmp_PAN)
 
-    npt.assert_almost_equal(ref_PAN, cmp_PAN)
+    npt.assert_allclose(cmp_PAN, ref_PAN, atol=1.5e-07)
 
     # Compare transformed pan
     cmp_pan = pan.PAN_
@@ -85,7 +85,7 @@ def test_aamp_stimp_1_percent(T):
     naive.replace_inf(ref_pan)
     naive.replace_inf(cmp_pan)
 
-    npt.assert_almost_equal(ref_pan, cmp_pan)
+    npt.assert_allclose(cmp_pan, ref_pan, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T", T)
@@ -126,7 +126,7 @@ def test_aamp_stimp_max_m(T):
     naive.replace_inf(ref_PAN)
     naive.replace_inf(cmp_PAN)
 
-    npt.assert_almost_equal(ref_PAN, cmp_PAN)
+    npt.assert_allclose(cmp_PAN, ref_PAN, atol=1.5e-07)
 
     # Compare transformed pan
     cmp_pan = pan.PAN_
@@ -143,7 +143,7 @@ def test_aamp_stimp_max_m(T):
     naive.replace_inf(ref_pan)
     naive.replace_inf(cmp_pan)
 
-    npt.assert_almost_equal(ref_pan, cmp_pan)
+    npt.assert_allclose(cmp_pan, ref_pan, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T", T)
@@ -178,7 +178,7 @@ def test_aamp_stimp_100_percent(T):
     naive.replace_inf(ref_PAN)
     naive.replace_inf(cmp_PAN)
 
-    npt.assert_almost_equal(ref_PAN, cmp_PAN)
+    npt.assert_allclose(cmp_PAN, ref_PAN, atol=1.5e-07)
 
     # Compare transformed pan
     cmp_pan = pan.PAN_
@@ -195,7 +195,7 @@ def test_aamp_stimp_100_percent(T):
     naive.replace_inf(ref_pan)
     naive.replace_inf(cmp_pan)
 
-    npt.assert_almost_equal(ref_pan, cmp_pan)
+    npt.assert_allclose(cmp_pan, ref_pan, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T", T)
@@ -226,7 +226,9 @@ def test_stimp_raw_mp(T):
 
         naive.replace_inf(ref_P_)
         naive.replace_inf(cmp_P_)
-        npt.assert_almost_equal(ref_P_, cmp_P_)
+        npt.assert_allclose(
+            cmp_P_.astype(np.float64), ref_P_.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -264,7 +266,7 @@ def test_aamp_stimped(T, dask_cluster):
         naive.replace_inf(ref_PAN)
         naive.replace_inf(cmp_PAN)
 
-        npt.assert_almost_equal(ref_PAN, cmp_PAN)
+        npt.assert_allclose(cmp_PAN, ref_PAN, atol=1.5e-07)
 
         # Compare transformed pan
         cmp_pan = pan.PAN_
@@ -281,4 +283,4 @@ def test_aamp_stimped(T, dask_cluster):
         naive.replace_inf(ref_pan)
         naive.replace_inf(cmp_pan)
 
-        npt.assert_almost_equal(ref_pan, cmp_pan)
+        npt.assert_allclose(cmp_pan, ref_pan, atol=1.5e-07)


### PR DESCRIPTION
Fixed #1175

Continuing the file-by-file split from #1178/#1181/#1182 — this one covers `tests/test_aamp_stimp.py`. Will open the next file's PR once this one merges.

`assert_almost_equal` only checks a fixed absolute tolerance and NumPy's docs recommend `assert_allclose` instead. 9 call sites, same recurring theme as the earlier files:

- The file already used `ref_`/`cmp_` naming, but the argument order was backwards everywhere (`ref_X, cmp_X` instead of `cmp_X, ref_X`) — flipped all 9.
- One site (`test_stimp_raw_mp`) compares `naive.aamp(...)[:, 0]` directly against `pan.P_[idx]`. The naive side stays `dtype=object` even after slicing out the distance column (same root cause as `test_aamp.py`), so I cast both sides to `float64` there. The other 8 sites build their `ref_PAN`/`ref_pan` arrays via `np.full(..., dtype)`-backed assignment rather than a raw slice, so they were already plain `float64` and didn't need casting — checked each site's actual dtype before deciding, rather than assuming based on the earlier files.

None of the original calls specified `decimal=`, so every site uses the default `atol=1.5e-07`.

Ran the full file twice locally (normal mode and JIT-disabled/CUDA-simulated, matching `test.sh coverage`) — 10/10 passing both times. This file also spins up a real dask `LocalCluster` for the `_stimped` tests, so it's slower than the non-dask files.

## To Do List

Standing checklist from @seanlaw for this migration, applies to every file in the split - status below is for `test_aamp_stimp.py`:

- [x] Each test file correctly replaces all uses of `npt.assert_almost_equal` with its equivalent `npt.assert_allclose`
- [x] When `rtol=0` for `npt.assert_allclose`, simply omit this parameter and value since this is the default
- [x] Ensure that `npt.assert_allclose(actual, desired)` always has the stumpy computed value as `actual` and the naive computation as `desired`
- [x] Use `atol=1.5e-07` rather than `atol=1.5*10**-07`
- [ ] Eventually, replace the ugly `1.5*10**-config.STUMPY_TEST_PRECISION` with `config.STUMPY_TEST_PRECISION = 1.5e-07` (in `config.py`) - tracked as a follow-up, not part of this per-file migration
- [x] Use `cmp` instead of `comp` - this file already used `cmp_` naming, nothing to rename
- [x] Rename naive outputs to `ref_` and stumpy-computed outputs to `cmp_` (applies to `npt.assert_array_equal` too) - this file already used `ref_`/`cmp_`, no `assert_array_equal` calls present

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
