### PR TITLE
Migrate tests/test_aampdist.py to npt.assert_allclose

### DIFF
--- a/tests/test_aampdist.py
+++ b/tests/test_aampdist.py
@@ -44,9 +44,9 @@ def test_aampdist_vect(T_A, T_B):
     m = 3
     for p in [1.0, 2.0, 3.0]:
         ref_aampdist_vect = naive.aampdist_vect(T_A, T_B, m, p=p)
-        comp_aampdist_vect = _aampdist_vect(T_A, T_B, m, p=p)
+        cmp_aampdist_vect = _aampdist_vect(T_A, T_B, m, p=p)
 
-        npt.assert_almost_equal(ref_aampdist_vect, comp_aampdist_vect)
+        npt.assert_allclose(cmp_aampdist_vect, ref_aampdist_vect, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -54,9 +54,9 @@ def test_aampdist_vect(T_A, T_B):
 def test_aampdist_vect_percentage(T_A, T_B, percentage):
     m = 3
     ref_aampdist_vect = naive.aampdist_vect(T_A, T_B, m, percentage=percentage)
-    comp_aampdist_vect = _aampdist_vect(T_A, T_B, m, percentage=percentage)
+    cmp_aampdist_vect = _aampdist_vect(T_A, T_B, m, percentage=percentage)
 
-    npt.assert_almost_equal(ref_aampdist_vect, comp_aampdist_vect)
+    npt.assert_allclose(cmp_aampdist_vect, ref_aampdist_vect, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -64,9 +64,9 @@ def test_aampdist_vect_percentage(T_A, T_B, percentage):
 def test_aampdist_vect_k(T_A, T_B, k):
     m = 3
     ref_aampdist_vect = naive.aampdist_vect(T_A, T_B, m, k=k)
-    comp_aampdist_vect = _aampdist_vect(T_A, T_B, m, k=k)
+    cmp_aampdist_vect = _aampdist_vect(T_A, T_B, m, k=k)
 
-    npt.assert_almost_equal(ref_aampdist_vect, comp_aampdist_vect)
+    npt.assert_allclose(cmp_aampdist_vect, ref_aampdist_vect, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -74,9 +74,9 @@ def test_aampdist(T_A, T_B):
     m = 3
     for p in [1.0, 2.0, 3.0]:
         ref_mpdist = naive.aampdist(T_A, T_B, m, p=p)
-        comp_mpdist = aampdist(T_A, T_B, m, p=p)
+        cmp_mpdist = aampdist(T_A, T_B, m, p=p)
 
-        npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+        npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -84,9 +84,9 @@ def test_aampdist(T_A, T_B):
 def test_aampdist_percentage(T_A, T_B, percentage):
     m = 3
     ref_mpdist = naive.aampdist(T_A, T_B, m, percentage=percentage)
-    comp_mpdist = aampdist(T_A, T_B, m, percentage=percentage)
+    cmp_mpdist = aampdist(T_A, T_B, m, percentage=percentage)
 
-    npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+    npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -94,9 +94,9 @@ def test_aampdist_percentage(T_A, T_B, percentage):
 def test_aampdist_k(T_A, T_B, k):
     m = 3
     ref_mpdist = naive.aampdist(T_A, T_B, m, k=k)
-    comp_mpdist = aampdist(T_A, T_B, m, k=k)
+    cmp_mpdist = aampdist(T_A, T_B, m, k=k)
 
-    npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+    npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -109,6 +109,6 @@ def test_aampdisted(T_A, T_B, dask_cluster):
         m = 3
         for p in [1.0, 2.0, 3.0]:
             ref_mpdist = naive.aampdist(T_A, T_B, m, p=p)
-            comp_mpdist = aampdisted(dask_client, T_A, T_B, m, p=p)
+            cmp_mpdist = aampdisted(dask_client, T_A, T_B, m, p=p)
 
-            npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+            npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

Continuing the file-by-file split from #1178/#1181/#1182/#1183 — this one covers `tests/test_aampdist.py`. Will open the next file's PR once this one merges.

`assert_almost_equal` only checks a fixed absolute tolerance and NumPy's docs recommend `assert_allclose` instead. 7 call sites, same two fixes as the earlier files:

- Renamed `comp_aampdist_vect`/`comp_mpdist` to `cmp_aampdist_vect`/`cmp_mpdist` per the standing convention.
- Argument order was backwards everywhere (`ref_X, comp_X` instead of `cmp_X, ref_X`) — flipped all 7.

Checked the return dtypes from `_aampdist_vect` and `aampdist` before touching anything — both come back plain `float64`, so no `.astype()` casting was needed here (unlike `test_aamp.py`/`test_aamp_motifs.py`/`test_aamp_stimp.py`, where the naive helper's mixed float/int output forced a cast). None of the original calls specified `decimal=`, so every site uses the default `atol=1.5e-07`.

Ran the full file twice locally (normal mode and JIT-disabled/CUDA-simulated, matching `test.sh coverage`) — 38/38 passing both times.

## To Do List

Standing checklist from @seanlaw for this migration, applies to every file in the split - status below is for `test_aampdist.py`:

- [x] Each test file correctly replaces all uses of `npt.assert_almost_equal` with its equivalent `npt.assert_allclose`
- [x] When `rtol=0` for `npt.assert_allclose`, simply omit this parameter and value since this is the default
- [x] Ensure that `npt.assert_allclose(actual, desired)` always has the stumpy computed value as `actual` and the naive computation as `desired`
- [x] Use `atol=1.5e-07` rather than `atol=1.5*10**-07`
- [ ] Eventually, replace the ugly `1.5*10**-config.STUMPY_TEST_PRECISION` with `config.STUMPY_TEST_PRECISION = 1.5e-07` (in `config.py`) - tracked as a follow-up, not part of this per-file migration
- [x] Use `cmp` instead of `comp` - this file used `comp_aampdist_vect`/`comp_mpdist`, both renamed
- [x] Rename naive outputs to `ref_` and stumpy-computed outputs to `cmp_` (applies to `npt.assert_array_equal` too) - this file already used `ref_`, no `assert_array_equal` calls present

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
