### PR TITLE
Migrate tests/test_aampdist_snippets.py to npt.assert_allclose

### DIFF
--- a/tests/test_aampdist_snippets.py
+++ b/tests/test_aampdist_snippets.py
@@ -35,22 +35,22 @@ def test_aampdist_snippets(T, m, k):
             cmp_regimes,
         ) = aampdist_snippets(T, m, k, p=p)
 
-        npt.assert_almost_equal(
-            ref_snippets, cmp_snippets, decimal=config.STUMPY_TEST_PRECISION
+        npt.assert_allclose(
+            cmp_snippets, ref_snippets, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
         )
-        npt.assert_almost_equal(
-            ref_indices, cmp_indices, decimal=config.STUMPY_TEST_PRECISION
+        npt.assert_allclose(
+            cmp_indices, ref_indices, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
         )
-        # npt.assert_almost_equal(
-        #     ref_profiles, cmp_profiles, decimal=config.STUMPY_TEST_PRECISION
+        # npt.assert_allclose(
+        #     cmp_profiles, ref_profiles, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
         # )
-        npt.assert_almost_equal(
-            ref_fractions, cmp_fractions, decimal=config.STUMPY_TEST_PRECISION
+        npt.assert_allclose(
+            cmp_fractions, ref_fractions, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
         )
-        # npt.assert_almost_equal(
-        #     ref_areas, cmp_areas, decimal=config.STUMPY_TEST_PRECISION
+        # npt.assert_allclose(
+        #     cmp_areas, ref_areas, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
         # )
-        npt.assert_almost_equal(ref_regimes, cmp_regimes)
+        npt.assert_allclose(cmp_regimes, ref_regimes, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T", test_data)
@@ -75,22 +75,22 @@ def test_mpdist_snippets_percentage(T, m, k, percentage):
         cmp_regimes,
     ) = aampdist_snippets(T, m, k, percentage=percentage)
 
-    npt.assert_almost_equal(
-        ref_snippets, cmp_snippets, decimal=config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        cmp_snippets, ref_snippets, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     )
-    npt.assert_almost_equal(
-        ref_indices, cmp_indices, decimal=config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        cmp_indices, ref_indices, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     )
-    # npt.assert_almost_equal(
-    #     ref_profiles, cmp_profiles, decimal=config.STUMPY_TEST_PRECISION
+    # npt.assert_allclose(
+    #     cmp_profiles, ref_profiles, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     # )
-    npt.assert_almost_equal(
-        ref_fractions, cmp_fractions, decimal=config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        cmp_fractions, ref_fractions, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     )
-    # npt.assert_almost_equal(
-    #     ref_areas, cmp_areas, decimal=config.STUMPY_TEST_PRECISION
+    # npt.assert_allclose(
+    #     cmp_areas, ref_areas, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     # )
-    npt.assert_almost_equal(ref_regimes, cmp_regimes)
+    npt.assert_allclose(cmp_regimes, ref_regimes, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T", test_data)
@@ -115,19 +115,19 @@ def test_aampdist_snippets_s(T, m, k, s):
         cmp_regimes,
     ) = aampdist_snippets(T, m, k, s=s)
 
-    npt.assert_almost_equal(
-        ref_snippets, cmp_snippets, decimal=config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        cmp_snippets, ref_snippets, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     )
-    npt.assert_almost_equal(
-        ref_indices, cmp_indices, decimal=config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        cmp_indices, ref_indices, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     )
-    # npt.assert_almost_equal(
-    #     ref_profiles, cmp_profiles, decimal=config.STUMPY_TEST_PRECISION
+    # npt.assert_allclose(
+    #     cmp_profiles, ref_profiles, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     # )
-    npt.assert_almost_equal(
-        ref_fractions, cmp_fractions, decimal=config.STUMPY_TEST_PRECISION
+    npt.assert_allclose(
+        cmp_fractions, ref_fractions, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     )
-    # npt.assert_almost_equal(
-    #     ref_areas, cmp_areas, decimal=config.STUMPY_TEST_PRECISION
+    # npt.assert_allclose(
+    #     cmp_areas, ref_areas, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     # )
-    npt.assert_almost_equal(ref_regimes, cmp_regimes)
+    npt.assert_allclose(cmp_regimes, ref_regimes, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

Continuing the file-by-file split — this one covers `tests/test_aampdist_snippets.py`.

`assert_almost_equal` only checks a fixed absolute tolerance and NumPy's docs recommend `assert_allclose` instead. This file already used `ref_`/`cmp_` naming, so the only changes needed:

- Argument order was backwards everywhere (`ref_x, cmp_x` instead of `cmp_x, ref_x`) — flipped every active call.
- Most calls explicitly pass `decimal=config.STUMPY_TEST_PRECISION` (a genuinely looser tolerance than the default, since `config.STUMPY_TEST_PRECISION` is `5`, not `7`) — kept these as `atol=1.5 * 10**-config.STUMPY_TEST_PRECISION` rather than flattening to the usual `1.5e-07` literal, since that would silently tighten the tolerance. Only the `regimes` comparison had no `decimal=` argument, so that one uses the default `atol=1.5e-07`.
- Two comparisons (`profiles`, `areas`) are commented out in the original file — updated their syntax to match for consistency, but left them commented since re-enabling them wasn't part of this migration.

Checked the actual return dtypes from `aampdist_snippets`/`naive.aampdist_snippets` first — all plain `float64`/`int64`, no `dtype=object` casting needed.

Ran the full file twice locally (normal mode and JIT-disabled/CUDA-simulated, matching `test.sh coverage`) — 63/63 passing both times (there are some pre-existing `RuntimeWarning: All-NaN slice encountered` warnings from `aampdist.py` itself, unrelated to this change).

## To Do List

Standing checklist from @seanlaw for this migration, applies to every file in the split - status below is for `test_aampdist_snippets.py`:

- [x] Each test file correctly replaces all uses of `npt.assert_almost_equal` with its equivalent `npt.assert_allclose`
- [x] When `rtol=0` for `npt.assert_allclose`, simply omit this parameter and value since this is the default
- [x] Ensure that `npt.assert_allclose(actual, desired)` always has the stumpy computed value as `actual` and the naive computation as `desired`
- [x] Use `atol=1.5e-07` rather than `atol=1.5*10**-07` - only applies to the one call site that used the implicit default; the rest reference `config.STUMPY_TEST_PRECISION` directly since that's a genuinely different (looser) tolerance
- [ ] Eventually, replace the ugly `1.5*10**-config.STUMPY_TEST_PRECISION` with `config.STUMPY_TEST_PRECISION = 1.5e-07` (in `config.py`) - tracked as a follow-up, not part of this per-file migration
- [x] Use `cmp` instead of `comp` - this file already used `cmp_` naming, nothing to rename
- [x] Rename naive outputs to `ref_` and stumpy-computed outputs to `cmp_` (applies to `npt.assert_array_equal` too) - this file already used `ref_`/`cmp_`, no `assert_array_equal` calls present
- [x] Titles/bodies no longer use closing keywords (`Fixed #N`) so individual file PRs don't prematurely auto-close #1175 - cross-referenced with `Related to #1175` instead

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
