### PR TITLE
Migrate tests/test_aamped.py to npt.assert_allclose

### DIFF
--- a/tests/test_aamped.py
+++ b/tests/test_aamped.py
@@ -57,10 +57,12 @@ def test_aamped_self_join(T_A, T_B, dask_cluster):
         m = 3
         for p in [1.0, 2.0, 3.0]:
             ref_mp = naive.aamp(T_B, m, p=p)
-            comp_mp = aamped(dask_client, T_B, m, p=p)
+            cmp_mp = aamped(dask_client, T_B, m, p=p)
             naive.replace_inf(ref_mp)
-            naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            naive.replace_inf(cmp_mp)
+            npt.assert_allclose(
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -72,10 +74,12 @@ def test_aamped_self_join_df(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
         ref_mp = naive.aamp(T_B, m)
-        comp_mp = aamped(dask_client, pd.Series(T_B), m)
+        cmp_mp = aamped(dask_client, pd.Series(T_B), m)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -88,11 +92,13 @@ def test_aamped_self_join_larger_window(T_A, T_B, m, dask_cluster):
     with Client(dask_cluster) as dask_client:
         if len(T_B) > m:
             ref_mp = naive.aamp(T_B, m)
-            comp_mp = aamped(dask_client, T_B, m)
+            cmp_mp = aamped(dask_client, T_B, m)
             naive.replace_inf(ref_mp)
-            naive.replace_inf(comp_mp)
+            naive.replace_inf(cmp_mp)
 
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            npt.assert_allclose(
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -105,11 +111,13 @@ def test_aamped_self_join_larger_window_df(T_A, T_B, m, dask_cluster):
     with Client(dask_cluster) as dask_client:
         if len(T_B) > m:
             ref_mp = naive.aamp(T_B, m)
-            comp_mp = aamped(dask_client, pd.Series(T_B), m)
+            cmp_mp = aamped(dask_client, pd.Series(T_B), m)
             naive.replace_inf(ref_mp)
-            naive.replace_inf(comp_mp)
+            naive.replace_inf(cmp_mp)
 
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            npt.assert_allclose(
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -122,10 +130,12 @@ def test_aamped_A_B_join(T_A, T_B, dask_cluster):
         m = 3
         for p in [1.0, 2.0, 3.0]:
             ref_mp = naive.aamp(T_A, m, T_B=T_B, p=p)
-            comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False, p=p)
+            cmp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False, p=p)
             naive.replace_inf(ref_mp)
-            naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            naive.replace_inf(cmp_mp)
+            npt.assert_allclose(
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -137,12 +147,14 @@ def test_aamped_A_B_join_df(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
         ref_mp = naive.aamp(T_A, m, T_B=T_B)
-        comp_mp = aamped(
+        cmp_mp = aamped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:A large number of values are smaller")
@@ -158,10 +170,14 @@ def test_aamped_one_constant_subsequence_self_join(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_A, m)
-        comp_mp = aamped(dask_client, T_A, m, ignore_trivial=True)
+        cmp_mp = aamped(dask_client, T_A, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:A large number of values are smaller")
@@ -177,10 +193,14 @@ def test_aamped_one_constant_subsequence_self_join_df(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_A, m)
-        comp_mp = aamped(dask_client, pd.Series(T_A), m, ignore_trivial=True)
+        cmp_mp = aamped(dask_client, pd.Series(T_A), m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -197,10 +217,14 @@ def test_aamped_one_constant_subsequence_A_B_join(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_A, m, T_B=T_B)
-        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -217,12 +241,16 @@ def test_aamped_one_constant_subsequence_A_B_join_df(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_A, m, T_B=T_B)
-        comp_mp = aamped(
+        cmp_mp = aamped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -239,10 +267,14 @@ def test_aamped_one_constant_subsequence_A_B_join_swap(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_A, m, T_B=T_B)
-        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -259,12 +291,16 @@ def test_aamped_one_constant_subsequence_A_B_join_df_swap(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_A, m, T_B=T_B)
-        comp_mp = aamped(
+        cmp_mp = aamped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:A large number of values are smaller")
@@ -281,11 +317,13 @@ def test_aamped_identical_subsequence_self_join(dask_cluster):
         T_A[11 : 11 + identical.shape[0]] = identical
         m = 3
         ref_mp = naive.aamp(T_A, m)
-        comp_mp = aamped(dask_client, T_A, m, ignore_trivial=True)
+        cmp_mp = aamped(dask_client, T_A, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(
-            ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
         )  # ignore indices
 
 
@@ -304,11 +342,13 @@ def test_aamped_identical_subsequence_A_B_join(dask_cluster):
         T_B[11 : 11 + identical.shape[0]] = identical
         m = 3
         ref_mp = naive.aamp(T_A, m, T_B=T_B)
-        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(
-            ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
         )  # ignore indices
 
 
@@ -328,10 +368,12 @@ def test_aamped_one_subsequence_inf_A_B_join(
         T_B_sub[substitution_location_B] = np.inf
 
         ref_mp = naive.aamp(T_A, m, T_B=T_B_sub)
-        comp_mp = aamped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -350,10 +392,12 @@ def test_aamped_one_subsequence_inf_self_join(
         T_B_sub[substitution_location_B] = np.inf
 
         ref_mp = naive.aamp(T_B_sub, m)
-        comp_mp = aamped(dask_client, T_B_sub, m, ignore_trivial=True)
+        cmp_mp = aamped(dask_client, T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -366,11 +410,13 @@ def test_aamped_nan_zero_mean_self_join(dask_cluster):
         m = 3
 
         ref_mp = naive.aamp(T, m)
-        comp_mp = aamped(dask_client, T, m, ignore_trivial=True)
+        cmp_mp = aamped(dask_client, T, m, ignore_trivial=True)
 
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -389,10 +435,12 @@ def test_aamped_one_subsequence_nan_A_B_join(
         T_B_sub[substitution_location_B] = np.nan
 
         ref_mp = naive.aamp(T_A, m, T_B=T_B_sub)
-        comp_mp = aamped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -411,10 +459,12 @@ def test_aamped_one_subsequence_nan_self_join(
         T_B_sub[substitution_location_B] = np.nan
 
         ref_mp = naive.aamp(T_B_sub, m)
-        comp_mp = aamped(dask_client, T_B_sub, m, ignore_trivial=True)
+        cmp_mp = aamped(dask_client, T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -434,10 +484,14 @@ def test_two_constant_subsequences_A_B_join_swap(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_B, m, T_B=T_A)
-        comp_mp = aamped(dask_client, T_B, m, T_A, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_B, m, T_A, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -457,12 +511,16 @@ def test_constant_subsequence_A_B_join_df_swap(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_B, m, T_B=T_A)
-        comp_mp = aamped(
+        cmp_mp = aamped(
             dask_client, pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -481,10 +539,14 @@ def test_two_constant_subsequences_A_B_join(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_A, m, T_B=T_B)
-        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -503,12 +565,16 @@ def test_two_constant_subsequences_A_B_join_df(dask_cluster):
         )
         m = 3
         ref_mp = naive.aamp(T_A, m, T_B=T_B)
-        comp_mp = aamped(
+        cmp_mp = aamped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp[:, 0].astype(np.float64),
+            ref_mp[:, 0].astype(np.float64),
+            atol=1.5e-07,
+        )  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -531,10 +597,12 @@ def test_aamped_two_subsequences_inf_A_B_join(
         T_B_sub[substitution_location_B] = np.inf
 
         ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-        comp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -557,10 +625,12 @@ def test_aamped_two_subsequences_nan_A_B_join(
         T_B_sub[substitution_location_B] = np.nan
 
         ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-        comp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -583,10 +653,12 @@ def test_aamped_two_subsequences_nan_inf_A_B_join(
         T_B_sub[substitution_location_B] = np.inf
 
         ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-        comp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -609,10 +681,12 @@ def test_aamped_two_subsequences_nan_inf_A_B_join_swap(
         T_B_sub[substitution_location_B] = np.nan
 
         ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-        comp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        cmp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -626,10 +700,12 @@ def test_aamped_self_join_KNN(T_A, T_B, dask_cluster):
         for k in range(2, 4):
             for p in [1.0, 2.0, 3.0]:
                 ref_mp = naive.aamp(T_B, m, p=p, k=k)
-                comp_mp = aamped(dask_client, T_B, m, p=p, k=k)
+                cmp_mp = aamped(dask_client, T_B, m, p=p, k=k)
                 naive.replace_inf(ref_mp)
-                naive.replace_inf(comp_mp)
-                npt.assert_almost_equal(ref_mp, comp_mp)
+                naive.replace_inf(cmp_mp)
+                npt.assert_allclose(
+                    cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+                )
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -643,9 +719,11 @@ def test_aamped_A_B_join_KNN(T_A, T_B, dask_cluster):
         for k in range(2, 4):
             for p in [1.0, 2.0, 3.0]:
                 ref_mp = naive.aamp(T_A, m, T_B=T_B, p=p, k=k)
-                comp_mp = aamped(
+                cmp_mp = aamped(
                     dask_client, T_A, m, T_B, ignore_trivial=False, p=p, k=k
                 )
                 naive.replace_inf(ref_mp)
-                naive.replace_inf(comp_mp)
-                npt.assert_almost_equal(ref_mp, comp_mp)
+                naive.replace_inf(cmp_mp)
+                npt.assert_allclose(
+                    cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+                )


### PR DESCRIPTION
Related to #1175

Continuing the file-by-file split — this one covers `tests/test_aamped.py` (the dask-parallel counterpart to `test_aamp.py`, same underlying comparisons just run through `aamped`/`dask_client`).

`assert_almost_equal` only checks a fixed absolute tolerance and NumPy's docs recommend `assert_allclose` instead. 29 call sites, structurally identical to `test_aamp.py`:

- Renamed `comp_mp` to `cmp_mp` per the standing convention (87 occurrences).
- Every comparison is against `ref_mp`/`cmp_mp`, which mix a float distance column with int index columns and so come back `dtype=object` — confirmed this before editing, same root cause as `test_aamp.py`. Cast both sides to `float64` on every site.
- 27 of the 29 sites had no `decimal=` argument, so those use `atol=1.5e-07`. 2 sites explicitly used `decimal=config.STUMPY_TEST_PRECISION` — kept those as `atol=1.5 * 10**-config.STUMPY_TEST_PRECISION` rather than flattening to the literal, since that's a genuinely different (looser) tolerance.

Ran the full file twice locally (normal mode and JIT-disabled/CUDA-simulated, matching `test.sh coverage`) — 102/102 passing both times (a handful of pre-existing warnings about small `P` values on the constant-subsequence tests, unrelated to this change).

## To Do List

Standing checklist from @seanlaw for this migration, applies to every file in the split - status below is for `test_aamped.py`:

- [x] Each test file correctly replaces all uses of `npt.assert_almost_equal` with its equivalent `npt.assert_allclose`
- [x] When `rtol=0` for `npt.assert_allclose`, simply omit this parameter and value since this is the default
- [x] Ensure that `npt.assert_allclose(actual, desired)` always has the stumpy computed value as `actual` and the naive computation as `desired`
- [x] Use `atol=1.5e-07` rather than `atol=1.5*10**-07` - applies to the 27 sites using the implicit default; the other 2 reference `config.STUMPY_TEST_PRECISION` directly since that's a genuinely different tolerance
- [ ] Eventually, replace the ugly `1.5*10**-config.STUMPY_TEST_PRECISION` with `config.STUMPY_TEST_PRECISION = 1.5e-07` (in `config.py`) - tracked as a follow-up, not part of this per-file migration
- [x] Use `cmp` instead of `comp` - this file used `comp_mp` throughout, all renamed
- [x] Rename naive outputs to `ref_` and stumpy-computed outputs to `cmp_` (applies to `npt.assert_array_equal` too) - this file already used `ref_`, no `assert_array_equal` calls present

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
