### PR TITLE
Migrate tests/test_aampi.py to npt.assert_allclose

### DIFF
--- a/tests/test_aampi.py
+++ b/tests/test_aampi.py
@@ -28,10 +28,10 @@ def test_aampi_self_join():
                 t = rng.RNG.rand()
                 stream.update(t)
 
-            comp_P = stream.P_
-            comp_I = stream.I_
-            comp_left_P = stream.left_P_
-            comp_left_I = stream.left_I_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
+            cmp_left_P = stream.left_P_
+            cmp_left_I = stream.left_I_
 
             ref_mp = naive.aamp(stream.T_, m, p=p)
             ref_P = ref_mp[:, 0]
@@ -46,13 +46,25 @@ def test_aampi_self_join():
 
             naive.replace_inf(ref_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_left_P.astype(np.float64),
+                ref_left_P.astype(np.float64),
+                atol=1.5e-07,
+            )
+            npt.assert_allclose(
+                cmp_left_I.astype(np.float64),
+                ref_left_I.astype(np.float64),
+                atol=1.5e-07,
+            )
 
         with rng.fix_state():
             n = 30
@@ -63,18 +75,30 @@ def test_aampi_self_join():
                 t = rng.RNG.rand()
                 stream.update(t)
 
-            comp_P = stream.P_
-            comp_I = stream.I_
-            comp_left_P = stream.left_P_
-            comp_left_I = stream.left_I_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
+            cmp_left_P = stream.left_P_
+            cmp_left_I = stream.left_I_
 
-            naive.replace_inf(comp_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_left_P.astype(np.float64),
+                ref_left_P.astype(np.float64),
+                atol=1.5e-07,
+            )
+            npt.assert_allclose(
+                cmp_left_I.astype(np.float64),
+                ref_left_I.astype(np.float64),
+                atol=1.5e-07,
+            )
 
 
 def test_aampi_self_join_egress():
@@ -93,20 +117,20 @@ def test_aampi_self_join_egress():
 
             stream = aampi(T, m, egress=True, p=p)
 
-            comp_P = stream.P_.copy()
-            comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            cmp_left_I = stream.left_I_
 
             naive.replace_inf(ref_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
             for i in range(34):
                 t = rng.RNG.rand()
@@ -114,10 +138,10 @@ def test_aampi_self_join_egress():
                 ref_mp.update(t)
                 stream.update(t)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_.copy()
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_.copy()
+                cmp_left_I = stream.left_I_
 
                 ref_P = ref_mp.P_.copy()
                 ref_I = ref_mp.I_
@@ -126,13 +150,13 @@ def test_aampi_self_join_egress():
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
         with rng.fix_state():
             T = rng.RNG.rand(n)
@@ -144,14 +168,14 @@ def test_aampi_self_join_egress():
 
             stream = aampi(T, m, egress=True, p=p)
 
-            comp_P = stream.P_.copy()
-            comp_I = stream.I_
+            cmp_P = stream.P_.copy()
+            cmp_I = stream.I_
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
             for i in range(34):
                 t = rng.RNG.rand()
@@ -159,10 +183,10 @@ def test_aampi_self_join_egress():
                 ref_mp.update(t)
                 stream.update(t)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_.copy()
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_.copy()
+                cmp_left_I = stream.left_I_
 
                 ref_P = ref_mp.P_.copy()
                 ref_I = ref_mp.I_
@@ -171,13 +195,13 @@ def test_aampi_self_join_egress():
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -198,8 +222,8 @@ def test_aampi_init_nan_inf_self_join(substitute, substitution_locations):
                 t = rng.RNG.rand()
                 stream.update(t)
 
-            comp_P = stream.P_
-            comp_I = stream.I_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
 
             stream.T_[substitution_location] = substitute
             ref_mp = naive.aamp(stream.T_, m)
@@ -207,9 +231,13 @@ def test_aampi_init_nan_inf_self_join(substitute, substitution_locations):
             ref_I = ref_mp[:, 1]
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
+            naive.replace_inf(cmp_P)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
 
         with rng.fix_state():
             n = 30
@@ -224,13 +252,17 @@ def test_aampi_init_nan_inf_self_join(substitute, substitution_locations):
                 t = rng.RNG.rand()
                 stream.update(t)
 
-            comp_P = stream.P_
-            comp_I = stream.I_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
 
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -255,20 +287,20 @@ def test_aampi_init_nan_inf_self_join_egress(substitute, substitution_locations)
 
             stream = aampi(T, m, egress=True)
 
-            comp_P = stream.P_.copy()
-            comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            cmp_left_I = stream.left_I_
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
             for i in range(34):
                 t = rng.RNG.rand()
@@ -276,10 +308,10 @@ def test_aampi_init_nan_inf_self_join_egress(substitute, substitution_locations)
                 ref_mp.update(t)
                 stream.update(t)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_.copy()
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_.copy()
+                cmp_left_I = stream.left_I_
 
                 ref_P = ref_mp.P_.copy()
                 ref_I = ref_mp.I_
@@ -288,13 +320,13 @@ def test_aampi_init_nan_inf_self_join_egress(substitute, substitution_locations)
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
         with rng.fix_state():
             n = 30
@@ -309,15 +341,15 @@ def test_aampi_init_nan_inf_self_join_egress(substitute, substitution_locations)
 
             stream = aampi(T, m, egress=True)
 
-            comp_P = stream.P_.copy()
-            comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            cmp_left_I = stream.left_I_
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_left_P)
 
             for i in range(34):
                 t = rng.RNG.rand()
@@ -325,10 +357,10 @@ def test_aampi_init_nan_inf_self_join_egress(substitute, substitution_locations)
                 ref_mp.update(t)
                 stream.update(t)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_.copy()
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_.copy()
+                cmp_left_I = stream.left_I_
 
                 ref_P = ref_mp.P_.copy()
                 ref_I = ref_mp.I_
@@ -337,13 +369,13 @@ def test_aampi_init_nan_inf_self_join_egress(substitute, substitution_locations)
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -363,8 +395,8 @@ def test_aampi_stream_nan_inf_self_join(substitute, substitution_locations):
             for t in T[n:]:
                 stream.update(t)
 
-            comp_P = stream.P_
-            comp_I = stream.I_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
 
             stream.T_[n:][substitution_location] = substitute
             ref_mp = naive.aamp(stream.T_, m)
@@ -372,10 +404,14 @@ def test_aampi_stream_nan_inf_self_join(substitute, substitution_locations):
             ref_I = ref_mp[:, 1]
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
 
         with rng.fix_state():
             T = rng.RNG.rand(64)
@@ -387,13 +423,17 @@ def test_aampi_stream_nan_inf_self_join(substitute, substitution_locations):
             for t in T[n:]:
                 stream.update(t)
 
-            comp_P = stream.P_
-            comp_I = stream.I_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
 
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -414,20 +454,20 @@ def test_aampi_stream_nan_inf_self_join_egress(substitute, substitution_location
 
             stream = aampi(T[:n], m, egress=True)
 
-            comp_P = stream.P_.copy()
-            comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            cmp_left_I = stream.left_I_
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
             if substitution_location == -1:
                 substitution_location = T[n:].shape[0] - 1
@@ -436,10 +476,10 @@ def test_aampi_stream_nan_inf_self_join_egress(substitute, substitution_location
                 ref_mp.update(t)
                 stream.update(t)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_.copy()
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_.copy()
+                cmp_left_I = stream.left_I_
 
                 ref_P = ref_mp.P_.copy()
                 ref_I = ref_mp.I_
@@ -448,13 +488,13 @@ def test_aampi_stream_nan_inf_self_join_egress(substitute, substitution_location
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
         with rng.fix_state():
             T = rng.RNG.rand(64)
@@ -467,20 +507,20 @@ def test_aampi_stream_nan_inf_self_join_egress(substitute, substitution_location
 
             stream = aampi(pd.Series(T[:n]), m, egress=True)
 
-            comp_P = stream.P_.copy()
-            comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            cmp_left_I = stream.left_I_
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
             if substitution_location == -1:  # pragma: no cover
                 substitution_location = T[n:].shape[0] - 1
             T[n:][substitution_location] = substitute
@@ -488,10 +528,10 @@ def test_aampi_stream_nan_inf_self_join_egress(substitute, substitution_location
                 ref_mp.update(t)
                 stream.update(t)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_.copy()
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_.copy()
+                cmp_left_I = stream.left_I_
 
                 ref_P = ref_mp.P_.copy()
                 ref_I = ref_mp.I_
@@ -500,13 +540,13 @@ def test_aampi_stream_nan_inf_self_join_egress(substitute, substitution_location
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
 
 def test_aampi_constant_subsequence_self_join():
@@ -521,18 +561,20 @@ def test_aampi_constant_subsequence_self_join():
             t = rng.RNG.rand()
             stream.update(t)
 
-        comp_P = stream.P_
-        # comp_I = stream.I_
+        cmp_P = stream.P_
+        # cmp_I = stream.I_
 
         ref_mp = naive.aamp(stream.T_, m)
         ref_P = ref_mp[:, 0]
         # ref_I = ref_mp[:, 1]
 
         naive.replace_inf(ref_P)
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        # npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(
+            cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+        )
+        # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
     with rng.fix_state():
         T = np.concatenate(
@@ -544,13 +586,15 @@ def test_aampi_constant_subsequence_self_join():
             t = rng.RNG.rand()
             stream.update(t)
 
-        comp_P = stream.P_
-        # comp_I = stream.I_
+        cmp_P = stream.P_
+        # cmp_I = stream.I_
 
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        # npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(
+            cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+        )
+        # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 def test_aampi_constant_subsequence_self_join_egress():
@@ -569,30 +613,30 @@ def test_aampi_constant_subsequence_self_join_egress():
 
         stream = aampi(T, m, egress=True)
 
-        comp_P = stream.P_.copy()
-        # comp_I = stream.I_
-        comp_left_P = stream.left_P_.copy()
-        # comp_left_I = stream.left_I_
+        cmp_P = stream.P_.copy()
+        # cmp_I = stream.I_
+        cmp_left_P = stream.left_P_.copy()
+        # cmp_left_I = stream.left_I_
 
         naive.replace_inf(ref_P)
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
         naive.replace_inf(ref_left_P)
-        naive.replace_inf(comp_left_P)
+        naive.replace_inf(cmp_left_P)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        # npt.assert_almost_equal(ref_I, comp_I)
-        npt.assert_almost_equal(ref_left_P, comp_left_P)
-        # npt.assert_almost_equal(ref_left_I, comp_left_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+        npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+        # npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
         for i in range(34):
             t = rng.RNG.rand()
             ref_mp.update(t)
             stream.update(t)
 
-            comp_P = stream.P_.copy()
-            # comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            # comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            # cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            # cmp_left_I = stream.left_I_
 
             ref_P = ref_mp.P_.copy()
             # ref_I = ref_mp.I_
@@ -601,13 +645,13 @@ def test_aampi_constant_subsequence_self_join_egress():
 
             naive.replace_inf(ref_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            # npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            # npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+            # npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
     with rng.fix_state():
         T = np.concatenate(
@@ -623,30 +667,30 @@ def test_aampi_constant_subsequence_self_join_egress():
 
         stream = aampi(T, m, egress=True)
 
-        comp_P = stream.P_.copy()
-        # comp_I = stream.I_
-        comp_left_P = stream.left_P_.copy()
-        # comp_left_I = stream.left_I_
+        cmp_P = stream.P_.copy()
+        # cmp_I = stream.I_
+        cmp_left_P = stream.left_P_.copy()
+        # cmp_left_I = stream.left_I_
 
         naive.replace_inf(ref_P)
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
         naive.replace_inf(ref_left_P)
-        naive.replace_inf(comp_left_P)
+        naive.replace_inf(cmp_left_P)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        # npt.assert_almost_equal(ref_I, comp_I)
-        npt.assert_almost_equal(ref_left_P, comp_left_P)
-        # npt.assert_almost_equal(ref_left_I, comp_left_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+        npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+        # npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
         for i in range(34):
             t = rng.RNG.rand()
             ref_mp.update(t)
             stream.update(t)
 
-            comp_P = stream.P_.copy()
-            # comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            # comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            # cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            # cmp_left_I = stream.left_I_
 
             ref_P = ref_mp.P_.copy()
             # ref_I = ref_mp.I_
@@ -655,13 +699,13 @@ def test_aampi_constant_subsequence_self_join_egress():
 
             naive.replace_inf(ref_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            # npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            # npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+            # npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
 
 def test_aampi_update_constant_subsequence_self_join():
@@ -677,14 +721,16 @@ def test_aampi_update_constant_subsequence_self_join():
         t = T_full[i]
         stream.update(t)
 
-    comp_P = stream.P_
+    cmp_P = stream.P_
 
     ref_mp = naive.aamp(stream.T_, m)
     ref_P = ref_mp[:, 0]
 
     naive.replace_inf(ref_P)
-    naive.replace_inf(comp_P)
-    npt.assert_almost_equal(ref_P, comp_P)
+    naive.replace_inf(cmp_P)
+    npt.assert_allclose(
+        cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+    )
 
     T_full = pd.Series(T_full)
     T_stream = T_full[:10].copy()
@@ -694,10 +740,12 @@ def test_aampi_update_constant_subsequence_self_join():
         t = T_full[i]
         stream.update(t)
 
-    comp_P = stream.P_
+    cmp_P = stream.P_
 
-    naive.replace_inf(comp_P)
-    npt.assert_almost_equal(ref_P, comp_P)
+    naive.replace_inf(cmp_P)
+    npt.assert_allclose(
+        cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+    )
 
 
 def test_aampi_update_constant_subsequence_self_join_egress():
@@ -718,19 +766,19 @@ def test_aampi_update_constant_subsequence_self_join_egress():
         ref_mp.update(t)
         stream.update(t)
 
-        comp_P = stream.P_.copy()
-        comp_left_P = stream.left_P_.copy()
+        cmp_P = stream.P_.copy()
+        cmp_left_P = stream.left_P_.copy()
 
         ref_P = ref_mp.P_.copy()
         ref_left_P = ref_mp.left_P_.copy()
 
         naive.replace_inf(ref_P)
         naive.replace_inf(ref_left_P)
-        naive.replace_inf(comp_P)
-        naive.replace_inf(comp_left_P)
+        naive.replace_inf(cmp_P)
+        naive.replace_inf(cmp_left_P)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
 
     T_full = pd.Series(T_full)
     T_stream = T_full[:10].copy()
@@ -746,19 +794,19 @@ def test_aampi_update_constant_subsequence_self_join_egress():
         ref_mp.update(t)
         stream.update(t)
 
-        comp_P = stream.P_.copy()
-        comp_left_P = stream.left_P_.copy()
+        cmp_P = stream.P_.copy()
+        cmp_left_P = stream.left_P_.copy()
 
         ref_P = ref_mp.P_.copy()
         ref_left_P = ref_mp.left_P_.copy()
 
         naive.replace_inf(ref_P)
         naive.replace_inf(ref_left_P)
-        naive.replace_inf(comp_P)
-        naive.replace_inf(comp_left_P)
+        naive.replace_inf(cmp_P)
+        naive.replace_inf(cmp_left_P)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
 
 
 def test_aampi_identical_subsequence_self_join():
@@ -773,18 +821,22 @@ def test_aampi_identical_subsequence_self_join():
             t = rng.RNG.rand()
             stream.update(t)
 
-        comp_P = stream.P_
-        # comp_I = stream.I_
+        cmp_P = stream.P_
+        # cmp_I = stream.I_
 
         ref_mp = naive.aamp(stream.T_, m)
         ref_P = ref_mp[:, 0]
         # ref_I = ref_mp[:, 1]
 
         naive.replace_inf(ref_P)
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
 
-        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(
+            cmp_P.astype(np.float64),
+            ref_P.astype(np.float64),
+            atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
+        )
+        # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
     with rng.fix_state():
         identical = rng.RNG.rand(8)
@@ -797,13 +849,17 @@ def test_aampi_identical_subsequence_self_join():
             t = rng.RNG.rand()
             stream.update(t)
 
-        comp_P = stream.P_
-        # comp_I = stream.I_
+        cmp_P = stream.P_
+        # cmp_I = stream.I_
 
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
 
-        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(
+            cmp_P.astype(np.float64),
+            ref_P.astype(np.float64),
+            atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
+        )
+        # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 def test_aampi_identical_subsequence_self_join_egress():
@@ -823,32 +879,32 @@ def test_aampi_identical_subsequence_self_join_egress():
 
         stream = aampi(T, m, egress=True)
 
-        comp_P = stream.P_.copy()
-        # comp_I = stream.I_
-        comp_left_P = stream.left_P_.copy()
-        # comp_left_I = stream.left_I_
+        cmp_P = stream.P_.copy()
+        # cmp_I = stream.I_
+        cmp_left_P = stream.left_P_.copy()
+        # cmp_left_I = stream.left_I_
 
         naive.replace_inf(ref_P)
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
         naive.replace_inf(ref_left_P)
-        naive.replace_inf(comp_left_P)
+        naive.replace_inf(cmp_left_P)
 
-        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(ref_I, comp_I)
-        npt.assert_almost_equal(
-            ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION)
+        # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+        npt.assert_allclose(
+            cmp_left_P, ref_left_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
         )
-        # npt.assert_almost_equal(ref_left_I, comp_left_I)
+        # npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
         for i in range(34):
             t = rng.RNG.rand()
             ref_mp.update(t)
             stream.update(t)
 
-            comp_P = stream.P_.copy()
-            # comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            # comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            # cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            # cmp_left_I = stream.left_I_
 
             ref_P = ref_mp.P_.copy()
             # ref_I = ref_mp.I_
@@ -857,15 +913,17 @@ def test_aampi_identical_subsequence_self_join_egress():
 
             naive.replace_inf(ref_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
-            # npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(
-                ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
+            npt.assert_allclose(
+                cmp_P, ref_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
             )
-            # npt.assert_almost_equal(ref_left_I, comp_left_I)
+            # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(
+                cmp_left_P, ref_left_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
+            )
+            # npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
     with rng.fix_state():
         identical = rng.RNG.rand(8)
@@ -882,32 +940,32 @@ def test_aampi_identical_subsequence_self_join_egress():
 
         stream = aampi(T, m, egress=True)
 
-        comp_P = stream.P_.copy()
-        # comp_I = stream.I_
-        comp_left_P = stream.left_P_.copy()
-        # comp_left_I = stream.left_I_
+        cmp_P = stream.P_.copy()
+        # cmp_I = stream.I_
+        cmp_left_P = stream.left_P_.copy()
+        # cmp_left_I = stream.left_I_
 
         naive.replace_inf(ref_P)
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
         naive.replace_inf(ref_left_P)
-        naive.replace_inf(comp_left_P)
+        naive.replace_inf(cmp_left_P)
 
-        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(ref_I, comp_I)
-        npt.assert_almost_equal(
-            ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION)
+        # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+        npt.assert_allclose(
+            cmp_left_P, ref_left_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
         )
-        # npt.assert_almost_equal(ref_left_I, comp_left_I)
+        # npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
         for i in range(34):
             t = rng.RNG.rand()
             ref_mp.update(t)
             stream.update(t)
 
-            comp_P = stream.P_.copy()
-            # comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            # comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            # cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            # cmp_left_I = stream.left_I_
 
             ref_P = ref_mp.P_.copy()
             # ref_I = ref_mp.I_
@@ -916,15 +974,17 @@ def test_aampi_identical_subsequence_self_join_egress():
 
             naive.replace_inf(ref_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
-            # npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(
-                ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
+            npt.assert_allclose(
+                cmp_P, ref_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
             )
-            # npt.assert_almost_equal(ref_left_I, comp_left_I)
+            # npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(
+                cmp_left_P, ref_left_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
+            )
+            # npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
 
 def test_aampi_profile_index_match():
@@ -935,28 +995,28 @@ def test_aampi_profile_index_match():
 
     T_stream = T_full[:warm_start].copy()
     stream = aampi(T_stream, m, egress=True)
-    P = np.full(stream.P_.shape, np.inf)
-    left_P = np.full(stream.left_P_.shape, np.inf)
+    ref_P = np.full(stream.P_.shape, np.inf)
+    ref_left_P = np.full(stream.left_P_.shape, np.inf)
 
     n = 0
     for i in range(len(T_stream), len(T_full)):
         t = T_full[i]
         stream.update(t)
 
-        P[:] = np.inf
+        ref_P[:] = np.inf
         idx = np.argwhere(stream.I_ >= 0).flatten()
-        P[idx] = naive.distance(
+        ref_P[idx] = naive.distance(
             T_full_subseq[idx + n + 1], T_full_subseq[stream.I_[idx]], axis=1
         )
 
-        left_P[:] = np.inf
+        ref_left_P[:] = np.inf
         idx = np.argwhere(stream.left_I_ >= 0).flatten()
-        left_P[idx] = naive.distance(
+        ref_left_P[idx] = naive.distance(
             T_full_subseq[idx + n + 1], T_full_subseq[stream.left_I_[idx]], axis=1
         )
 
-        npt.assert_almost_equal(stream.P_, P)
-        npt.assert_almost_equal(stream.left_P_, left_P)
+        npt.assert_allclose(stream.P_, ref_P, atol=1.5e-07)
+        npt.assert_allclose(stream.left_P_, ref_left_P, atol=1.5e-07)
 
         n += 1
 
@@ -973,10 +1033,10 @@ def test_aampi_self_join_KNN():
                     t = rng.RNG.rand()
                     stream.update(t)
 
-                comp_P = stream.P_
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_
+                cmp_left_I = stream.left_I_
 
                 ref_mp = naive.aamp(stream.T_, m, p=p, k=k)
                 ref_P = ref_mp[:, :k]
@@ -992,13 +1052,25 @@ def test_aampi_self_join_KNN():
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(
+                    cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+                )
+                npt.assert_allclose(
+                    cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+                )
+                npt.assert_allclose(
+                    cmp_left_P.astype(np.float64),
+                    ref_left_P.astype(np.float64),
+                    atol=1.5e-07,
+                )
+                npt.assert_allclose(
+                    cmp_left_I.astype(np.float64),
+                    ref_left_I.astype(np.float64),
+                    atol=1.5e-07,
+                )
 
             with rng.fix_state():
                 n = 30
@@ -1009,18 +1081,30 @@ def test_aampi_self_join_KNN():
                     t = rng.RNG.rand()
                     stream.update(t)
 
-                comp_P = stream.P_
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_
+                cmp_left_I = stream.left_I_
 
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(
+                    cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+                )
+                npt.assert_allclose(
+                    cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+                )
+                npt.assert_allclose(
+                    cmp_left_P.astype(np.float64),
+                    ref_left_P.astype(np.float64),
+                    atol=1.5e-07,
+                )
+                npt.assert_allclose(
+                    cmp_left_I.astype(np.float64),
+                    ref_left_I.astype(np.float64),
+                    atol=1.5e-07,
+                )
 
 
 def test_aampi_self_join_egress_KNN():
@@ -1039,20 +1123,20 @@ def test_aampi_self_join_egress_KNN():
 
                 stream = aampi(T, m, egress=True, p=p, k=k)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_.copy()
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_.copy()
+                cmp_left_I = stream.left_I_
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
                 for i in range(34):
                     t = rng.RNG.rand()
@@ -1060,10 +1144,10 @@ def test_aampi_self_join_egress_KNN():
                     ref_mp.update(t)
                     stream.update(t)
 
-                    comp_P = stream.P_.copy()
-                    comp_I = stream.I_
-                    comp_left_P = stream.left_P_.copy()
-                    comp_left_I = stream.left_I_
+                    cmp_P = stream.P_.copy()
+                    cmp_I = stream.I_
+                    cmp_left_P = stream.left_P_.copy()
+                    cmp_left_I = stream.left_I_
 
                     ref_P = ref_mp.P_.copy()
                     ref_I = ref_mp.I_
@@ -1072,13 +1156,13 @@ def test_aampi_self_join_egress_KNN():
 
                     naive.replace_inf(ref_P)
                     naive.replace_inf(ref_left_P)
-                    naive.replace_inf(comp_P)
-                    naive.replace_inf(comp_left_P)
+                    naive.replace_inf(cmp_P)
+                    naive.replace_inf(cmp_left_P)
 
-                    npt.assert_almost_equal(ref_P, comp_P)
-                    npt.assert_almost_equal(ref_I, comp_I)
-                    npt.assert_almost_equal(ref_left_P, comp_left_P)
-                    npt.assert_almost_equal(ref_left_I, comp_left_I)
+                    npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                    npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                    npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                    npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
             with rng.fix_state():
                 T = rng.RNG.rand(n)
@@ -1090,14 +1174,14 @@ def test_aampi_self_join_egress_KNN():
 
                 stream = aampi(T, m, egress=True, p=p, k=k)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
 
                 naive.replace_inf(ref_P)
-                naive.replace_inf(comp_P)
+                naive.replace_inf(cmp_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
                 for i in range(34):
                     t = rng.RNG.rand()
@@ -1105,10 +1189,10 @@ def test_aampi_self_join_egress_KNN():
                     ref_mp.update(t)
                     stream.update(t)
 
-                    comp_P = stream.P_.copy()
-                    comp_I = stream.I_
-                    comp_left_P = stream.left_P_.copy()
-                    comp_left_I = stream.left_I_
+                    cmp_P = stream.P_.copy()
+                    cmp_I = stream.I_
+                    cmp_left_P = stream.left_P_.copy()
+                    cmp_left_I = stream.left_I_
 
                     ref_P = ref_mp.P_.copy()
                     ref_I = ref_mp.I_
@@ -1117,13 +1201,13 @@ def test_aampi_self_join_egress_KNN():
 
                     naive.replace_inf(ref_P)
                     naive.replace_inf(ref_left_P)
-                    naive.replace_inf(comp_P)
-                    naive.replace_inf(comp_left_P)
+                    naive.replace_inf(cmp_P)
+                    naive.replace_inf(cmp_left_P)
 
-                    npt.assert_almost_equal(ref_P, comp_P)
-                    npt.assert_almost_equal(ref_I, comp_I)
-                    npt.assert_almost_equal(ref_left_P, comp_left_P)
-                    npt.assert_almost_equal(ref_left_I, comp_left_I)
+                    npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                    npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                    npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                    npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
 
 def test_aampi_self_join_egress_passing_mp():
@@ -1143,20 +1227,20 @@ def test_aampi_self_join_egress_passing_mp():
 
             stream = aampi(T, m, egress=True, p=p, mp=mp)
 
-            comp_P = stream.P_.copy()
-            comp_I = stream.I_
-            comp_left_P = stream.left_P_.copy()
-            comp_left_I = stream.left_I_
+            cmp_P = stream.P_.copy()
+            cmp_I = stream.I_
+            cmp_left_P = stream.left_P_.copy()
+            cmp_left_I = stream.left_I_
 
             naive.replace_inf(ref_P)
             naive.replace_inf(ref_left_P)
-            naive.replace_inf(comp_P)
-            naive.replace_inf(comp_left_P)
+            naive.replace_inf(cmp_P)
+            naive.replace_inf(cmp_left_P)
 
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_left_P, comp_left_P)
-            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+            npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)
 
             for i in range(34):
                 t = rng.RNG.rand()
@@ -1164,10 +1248,10 @@ def test_aampi_self_join_egress_passing_mp():
                 ref_mp.update(t)
                 stream.update(t)
 
-                comp_P = stream.P_.copy()
-                comp_I = stream.I_
-                comp_left_P = stream.left_P_.copy()
-                comp_left_I = stream.left_I_
+                cmp_P = stream.P_.copy()
+                cmp_I = stream.I_
+                cmp_left_P = stream.left_P_.copy()
+                cmp_left_I = stream.left_I_
 
                 ref_P = ref_mp.P_.copy()
                 ref_I = ref_mp.I_
@@ -1176,10 +1260,10 @@ def test_aampi_self_join_egress_passing_mp():
 
                 naive.replace_inf(ref_P)
                 naive.replace_inf(ref_left_P)
-                naive.replace_inf(comp_P)
-                naive.replace_inf(comp_left_P)
+                naive.replace_inf(cmp_P)
+                naive.replace_inf(cmp_left_P)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
-                npt.assert_almost_equal(ref_left_P, comp_left_P)
-                npt.assert_almost_equal(ref_left_I, comp_left_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_P, ref_left_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_left_I, ref_left_I, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

Continuing the file-by-file split — this one covers `tests/test_aampi.py`. Largest file in the split so far (138 call sites across 17 test functions), so it's worth explaining the approach.

`assert_almost_equal` only checks a fixed absolute tolerance and NumPy's docs recommend `assert_allclose` instead. Renamed `comp_P`/`comp_I`/`comp_left_P`/`comp_left_I` to `cmp_*` per the standing convention, and flipped every call to the `actual, desired` order. The tricky part was `dtype=object` casting, which only applies to *some* of the functions here depending on where `ref_*` comes from:

- 7 functions build `ref_P`/`ref_I`/`ref_left_I` by slicing columns out of `naive.aamp(...)` (e.g. `ref_mp[:, 0]`) — that stays `dtype=object` even after column-slicing (same root cause as `test_aamp.py`/`test_aamped.py`), so these needed `.astype(np.float64)` on both sides.
- 8 functions instead build `ref_P`/`ref_I`/`ref_left_P`/`ref_left_I` from `naive.aampi_egress(...).P_`/`.I_`/etc — a dedicated streaming reference implementation that returns plain `float64`/`int64` directly, no casting needed.
- I checked the actual runtime dtype of every distinct source in this file before writing any of the migration, rather than assuming based on the earlier files, since guessing here would've been easy to get wrong in either direction.
- `test_aampi_profile_index_match` doesn't use the `ref_`/`comp_` convention at all — it built local `P`/`left_P` arrays and compared them directly against `stream.P_`/`stream.left_P_` (already in the correct `actual, desired` order). Renamed those two locals to `ref_P`/`ref_left_P` for consistency with the rest of the file.
- 2 functions explicitly pass `decimal=config.STUMPY_TEST_PRECISION` — kept those as `atol=1.5 * 10**-config.STUMPY_TEST_PRECISION` rather than the `1.5e-07` literal, same as the earlier files.

Ran the full file twice locally (normal mode and JIT-disabled/CUDA-simulated, matching `test.sh coverage`) — 21/21 passing both times.

## To Do List

Standing checklist from @seanlaw for this migration, applies to every file in the split - status below is for `test_aampi.py`:

- [x] Each test file correctly replaces all uses of `npt.assert_almost_equal` with its equivalent `npt.assert_allclose`
- [x] When `rtol=0` for `npt.assert_allclose`, simply omit this parameter and value since this is the default
- [x] Ensure that `npt.assert_allclose(actual, desired)` always has the stumpy computed value as `actual` and the naive computation as `desired`
- [x] Use `atol=1.5e-07` rather than `atol=1.5*10**-07` - applies to the sites using the implicit default; the `config.STUMPY_TEST_PRECISION`-referencing sites keep that reference
- [ ] Eventually, replace the ugly `1.5*10**-config.STUMPY_TEST_PRECISION` with `config.STUMPY_TEST_PRECISION = 1.5e-07` (in `config.py`) - tracked as a follow-up, not part of this per-file migration
- [x] Use `cmp` instead of `comp` - this file used `comp_P`/`comp_I`/`comp_left_P`/`comp_left_I` throughout, all renamed
- [x] Rename naive outputs to `ref_` and stumpy-computed outputs to `cmp_` (applies to `npt.assert_array_equal` too) - this file already used `ref_`/`comp_`, no `assert_array_equal` calls present; also renamed the one function that used bare `P`/`left_P` instead

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
