### PR TITLE
Migrate tests/test_floss.py to npt.assert_allclose

### DIFF
--- a/tests/test_floss.py
+++ b/tests/test_floss.py
@@ -103,8 +103,8 @@ substitution_values = [np.nan, np.inf]
 @pytest.mark.parametrize("I", test_data)
 def test_nnmark(I):
     ref = naive_nnmark(I)
-    comp = _nnmark(I)
-    npt.assert_almost_equal(ref, comp)
+    cmp = _nnmark(I)
+    npt.assert_allclose(cmp, ref, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("I", test_data)
@@ -114,8 +114,8 @@ def test_cac(I):
     custom_iac = _iac(I.shape[0])
     ref = naive_cac(I, L, excl_factor, custom_iac)
     bidirectional = True
-    comp = _cac(I, L, bidirectional, excl_factor)
-    npt.assert_almost_equal(ref, comp)
+    cmp = _cac(I, L, bidirectional, excl_factor)
+    npt.assert_allclose(cmp, ref, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("I", test_data)
@@ -125,8 +125,8 @@ def test_cac_custom_iac(I):
     ref = naive_cac(I, L, excl_factor)
     custom_iac = naive_iac(I.shape[0])
     bidirectional = True
-    comp = _cac(I, L, bidirectional, excl_factor, custom_iac)
-    npt.assert_almost_equal(ref, comp)
+    cmp = _cac(I, L, bidirectional, excl_factor, custom_iac)
+    npt.assert_allclose(cmp, ref, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("I", test_data)
@@ -136,8 +136,8 @@ def test_rea(I):
     cac = naive_cac(I, L, excl_factor)
     n_regimes = 3
     ref = naive_rea(cac, n_regimes, L, excl_factor)
-    comp = _rea(cac, n_regimes, L, excl_factor)
-    npt.assert_almost_equal(ref, comp)
+    cmp = _rea(cac, n_regimes, L, excl_factor)
+    npt.assert_allclose(cmp, ref, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("I", test_data)
@@ -148,9 +148,9 @@ def test_fluss(I):
     ref_cac = naive_cac(I, L, excl_factor)
     n_regimes = 3
     ref_rea = naive_rea(ref_cac, n_regimes, L, excl_factor)
-    comp_cac, comp_rea = fluss(I, L, n_regimes, excl_factor, custom_iac)
-    npt.assert_almost_equal(ref_cac, comp_cac)
-    npt.assert_almost_equal(ref_rea, comp_rea)
+    cmp_cac, cmp_rea = fluss(I, L, n_regimes, excl_factor, custom_iac)
+    npt.assert_allclose(cmp_cac, ref_cac, atol=1.5e-07)
+    npt.assert_allclose(cmp_rea, ref_rea, atol=1.5e-07)
 
 
 def test_floss():
@@ -160,14 +160,14 @@ def test_floss():
     old_data = data[:n]
 
     mp = naive_right_mp(old_data, m)
-    comp_mp = stump(old_data, m)
+    cmp_mp = stump(old_data, m)
     k = mp.shape[0]
 
     rolling_Ts = core.rolling_window(data[1:], n)
     L = 5
     excl_factor = 1
     custom_iac = _iac(k, bidirectional=False)
-    stream = floss(comp_mp, old_data, m, L, excl_factor, custom_iac=custom_iac)
+    stream = floss(cmp_mp, old_data, m, L, excl_factor, custom_iac=custom_iac)
     last_idx = n - m + 1
     excl_zone = int(np.ceil(m / 4))
     zone_start = max(0, k - excl_zone)
@@ -199,19 +199,23 @@ def test_floss():
         ref_I[ref_mp[:, 0] == np.inf] = -1
 
         stream.update(ref_T[-1])
-        comp_cac_1d = stream.cac_1d_
-        comp_P = stream.P_
+        cmp_cac_1d = stream.cac_1d_
+        cmp_P = stream.P_
 
-        comp_I = stream.I_
-        comp_T = stream.T_
+        cmp_I = stream.I_
+        cmp_T = stream.T_
 
         naive.replace_inf(ref_P)
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
 
-        npt.assert_almost_equal(ref_cac_1d, comp_cac_1d)
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
-        npt.assert_almost_equal(ref_T, comp_T)
+        npt.assert_allclose(cmp_cac_1d, ref_cac_1d, atol=1.5e-07)
+        npt.assert_allclose(
+            cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+        )
+        npt.assert_allclose(
+            cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+        )
+        npt.assert_allclose(cmp_T, ref_T, atol=1.5e-07)
 
 
 def test_aamp_floss():
@@ -222,7 +226,7 @@ def test_aamp_floss():
 
     for p in range(1, 4):
         mp = naive_right_mp(old_data, m, normalize=False, p=p)
-        comp_mp = aamp(old_data, m, p=p)
+        cmp_mp = aamp(old_data, m, p=p)
         k = mp.shape[0]
 
         rolling_Ts = core.rolling_window(data[1:], n)
@@ -230,7 +234,7 @@ def test_aamp_floss():
         excl_factor = 1
         custom_iac = _iac(k, bidirectional=False)
         stream = floss(
-            comp_mp,
+            cmp_mp,
             old_data,
             m,
             L,
@@ -270,18 +274,22 @@ def test_aamp_floss():
             ref_I[ref_mp[:, 0] == np.inf] = -1
 
             stream.update(ref_T[-1])
-            comp_cac_1d = stream.cac_1d_
-            comp_P = stream.P_
-            comp_I = stream.I_
-            comp_T = stream.T_
+            cmp_cac_1d = stream.cac_1d_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
+            cmp_T = stream.T_
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
 
-            npt.assert_almost_equal(ref_cac_1d, comp_cac_1d)
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_T, comp_T)
+            npt.assert_allclose(cmp_cac_1d, ref_cac_1d, atol=1.5e-07)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(cmp_T, ref_T, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -297,14 +305,14 @@ def test_floss_inf_nan(substitute, substitution_locations):
         old_data = data[:n]
 
         mp = naive_right_mp(old_data, m)
-        comp_mp = stump(old_data, m)
+        cmp_mp = stump(old_data, m)
         k = mp.shape[0]
 
         rolling_Ts = core.rolling_window(data[1:], n)
         L = 5
         excl_factor = 1
         custom_iac = _iac(k, bidirectional=False)
-        stream = floss(comp_mp, old_data, m, L, excl_factor, custom_iac=custom_iac)
+        stream = floss(cmp_mp, old_data, m, L, excl_factor, custom_iac=custom_iac)
         last_idx = n - m + 1
         excl_zone = int(np.ceil(m / 4))
         zone_start = max(0, k - excl_zone)
@@ -342,18 +350,22 @@ def test_floss_inf_nan(substitute, substitution_locations):
             ref_I[ref_mp[:, 0] == np.inf] = -1
 
             stream.update(ref_T[-1])
-            comp_cac_1d = stream.cac_1d_
-            comp_P = stream.P_
-            comp_I = stream.I_
-            comp_T = stream.T_
+            cmp_cac_1d = stream.cac_1d_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
+            cmp_T = stream.T_
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
 
-            npt.assert_almost_equal(ref_cac_1d, comp_cac_1d)
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_T, comp_T)
+            npt.assert_allclose(cmp_cac_1d, ref_cac_1d, atol=1.5e-07)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(cmp_T, ref_T, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -369,7 +381,7 @@ def test_aamp_floss_inf_nan(substitute, substitution_locations):
         old_data = data[:n]
 
         mp = naive_right_mp(old_data, m, normalize=False)
-        comp_mp = aamp(old_data, m)
+        cmp_mp = aamp(old_data, m)
         k = mp.shape[0]
 
         rolling_Ts = core.rolling_window(data[1:], n)
@@ -377,7 +389,7 @@ def test_aamp_floss_inf_nan(substitute, substitution_locations):
         excl_factor = 1
         custom_iac = _iac(k, bidirectional=False)
         stream = floss(
-            comp_mp, old_data, m, L, excl_factor, custom_iac=custom_iac, normalize=False
+            cmp_mp, old_data, m, L, excl_factor, custom_iac=custom_iac, normalize=False
         )
         last_idx = n - m + 1
         excl_zone = int(np.ceil(m / 4))
@@ -416,18 +428,22 @@ def test_aamp_floss_inf_nan(substitute, substitution_locations):
             ref_I[ref_mp[:, 0] == np.inf] = -1
 
             stream.update(ref_T[-1])
-            comp_cac_1d = stream.cac_1d_
-            comp_P = stream.P_
-            comp_I = stream.I_
-            comp_T = stream.T_
+            cmp_cac_1d = stream.cac_1d_
+            cmp_P = stream.P_
+            cmp_I = stream.I_
+            cmp_T = stream.T_
 
             naive.replace_inf(ref_P)
-            naive.replace_inf(comp_P)
+            naive.replace_inf(cmp_P)
 
-            npt.assert_almost_equal(ref_cac_1d, comp_cac_1d)
-            npt.assert_almost_equal(ref_P, comp_P)
-            npt.assert_almost_equal(ref_I, comp_I)
-            npt.assert_almost_equal(ref_T, comp_T)
+            npt.assert_allclose(cmp_cac_1d, ref_cac_1d, atol=1.5e-07)
+            npt.assert_allclose(
+                cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(
+                cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+            )
+            npt.assert_allclose(cmp_T, ref_T, atol=1.5e-07)
 
 
 def test_floss_with_isconstant():
@@ -445,7 +461,7 @@ def test_floss_with_isconstant():
     )
 
     mp = naive_right_mp(T=old_data, m=m, T_subseq_isconstant=isconstant_custom_func)
-    comp_mp = stump(T_A=old_data, m=m, T_A_subseq_isconstant=isconstant_custom_func)
+    cmp_mp = stump(T_A=old_data, m=m, T_A_subseq_isconstant=isconstant_custom_func)
     k = mp.shape[0]
 
     rolling_Ts = core.rolling_window(data[1:], n)
@@ -453,7 +469,7 @@ def test_floss_with_isconstant():
     excl_factor = 1
     custom_iac = _iac(k, bidirectional=False)
     stream = floss(
-        comp_mp,
+        cmp_mp,
         old_data,
         m,
         L,
@@ -502,15 +518,19 @@ def test_floss_with_isconstant():
         ref_I[ref_mp[:, 0] == np.inf] = -1
 
         stream.update(ref_T[-1])
-        comp_cac_1d = stream.cac_1d_
-        comp_P = stream.P_
-        comp_I = stream.I_
-        comp_T = stream.T_
+        cmp_cac_1d = stream.cac_1d_
+        cmp_P = stream.P_
+        cmp_I = stream.I_
+        cmp_T = stream.T_
 
         naive.replace_inf(ref_P)
-        naive.replace_inf(comp_P)
+        naive.replace_inf(cmp_P)
 
-        npt.assert_almost_equal(ref_cac_1d, comp_cac_1d)
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
-        npt.assert_almost_equal(ref_T, comp_T)
+        npt.assert_allclose(cmp_cac_1d, ref_cac_1d, atol=1.5e-07)
+        npt.assert_allclose(
+            cmp_P.astype(np.float64), ref_P.astype(np.float64), atol=1.5e-07
+        )
+        npt.assert_allclose(
+            cmp_I.astype(np.float64), ref_I.astype(np.float64), atol=1.5e-07
+        )
+        npt.assert_allclose(cmp_T, ref_T, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

Covers `tests/test_floss.py` (26 call sites). Renamed `comp` to `cmp`, flipped every call to `(cmp, ref)` order.

Only two of the four values compared per site needed a `float64` cast: `ref_P`/`ref_I` come from slicing `stump()`/`aamp()` output, which is `dtype=object` (mixes the distance and index columns), same issue as the earlier files. `ref_cac_1d` and `ref_T` are already clean, so those stayed uncast.

12/12 passing locally in both normal and CI-equivalent (JIT-disabled, CUDA-simulated) modes.

## To Do List

- [x] `assert_almost_equal` -> `assert_allclose`
- [x] no `rtol=0`
- [x] `actual, desired` order (cmp first, ref second)
- [x] `atol=1.5e-07` literal - no `decimal=`/config references in this file
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp_` naming, casted only where the source is genuinely `dtype=object`

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
