### PR TITLE
Migrate tests/test_gpu_mpdist.py to npt.assert_allclose

### DIFF
--- a/tests/test_gpu_mpdist.py
+++ b/tests/test_gpu_mpdist.py
@@ -44,9 +44,9 @@ test_data = [
 def test_gpu_mpdist(T_A, T_B):
     m = 3
     ref_mpdist = naive.mpdist(T_A, T_B, m)
-    comp_mpdist = gpu_mpdist(T_A, T_B, m)
+    cmp_mpdist = gpu_mpdist(T_A, T_B, m)
 
-    npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+    npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -65,7 +65,7 @@ def test_gpu_mpdist_with_isconstant(T_A, T_B):
         T_A_subseq_isconstant=isconstant_custom_func,
         T_B_subseq_isconstant=isconstant_custom_func,
     )
-    comp_mpdist = gpu_mpdist(
+    cmp_mpdist = gpu_mpdist(
         T_A,
         T_B,
         m,
@@ -73,4 +73,4 @@ def test_gpu_mpdist_with_isconstant(T_A, T_B):
         T_B_subseq_isconstant=isconstant_custom_func,
     )
 
-    npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+    npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

Covers `tests/test_gpu_mpdist.py` (2 call sites). Renamed `comp_mpdist` to `cmp_mpdist`, flipped to `(cmp, ref)` order. Both scalar values are plain `float64`, no casting needed.

Only runs under CUDA — locally it's a module-level skip, verified with `NUMBA_ENABLE_CUDASIM=1`: 4/4 passing.

## To Do List

- [x] `assert_almost_equal` -> `assert_allclose`
- [x] no `rtol=0`
- [x] `actual, desired` order
- [x] `atol=1.5e-07`
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp_` naming, no casting needed

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
