### PR TITLE
Migrate tests/test_gpu_ostinato.py to npt.assert_allclose

### DIFF
--- a/tests/test_gpu_ostinato.py
+++ b/tests/test_gpu_ostinato.py
@@ -37,11 +37,11 @@ def test_random_gpu_ostinato(runs):
     Ts = [rng.RNG.rand(n) for n in [64, 128, 256]]
 
     ref_radius, ref_Ts_idx, ref_subseq_idx = naive.ostinato(Ts, m)
-    comp_radius, comp_Ts_idx, comp_subseq_idx = gpu_ostinato(Ts, m)
+    cmp_radius, cmp_Ts_idx, cmp_subseq_idx = gpu_ostinato(Ts, m)
 
-    npt.assert_almost_equal(ref_radius, comp_radius)
-    npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-    npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+    npt.assert_allclose(cmp_radius, ref_radius, atol=1.5e-07)
+    npt.assert_allclose(cmp_Ts_idx, ref_Ts_idx, atol=1.5e-07)
+    npt.assert_allclose(cmp_subseq_idx, ref_subseq_idx, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -54,11 +54,11 @@ def test_deterministic_gpu_ostinato(seed):
         Ts = [rng.RNG.rand(n) for n in [64, 128, 256]]
 
         ref_radius, ref_Ts_idx, ref_subseq_idx = naive.ostinato(Ts, m)
-        comp_radius, comp_Ts_idx, comp_subseq_idx = gpu_ostinato(Ts, m)
+        cmp_radius, cmp_Ts_idx, cmp_subseq_idx = gpu_ostinato(Ts, m)
 
-        npt.assert_almost_equal(ref_radius, comp_radius)
-        npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-        npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+        npt.assert_allclose(cmp_radius, ref_radius, atol=1.5e-07)
+        npt.assert_allclose(cmp_Ts_idx, ref_Ts_idx, atol=1.5e-07)
+        npt.assert_allclose(cmp_subseq_idx, ref_subseq_idx, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -76,13 +76,13 @@ def test_random_gpu_ostinato_with_isconstant(runs):
     ref_radius, ref_Ts_idx, ref_subseq_idx = naive.ostinato(
         Ts, m, Ts_subseq_isconstant=Ts_subseq_isconstant
     )
-    comp_radius, comp_Ts_idx, comp_subseq_idx = gpu_ostinato(
+    cmp_radius, cmp_Ts_idx, cmp_subseq_idx = gpu_ostinato(
         Ts, m, Ts_subseq_isconstant=Ts_subseq_isconstant
     )
 
-    npt.assert_almost_equal(ref_radius, comp_radius)
-    npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-    npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+    npt.assert_allclose(cmp_radius, ref_radius, atol=1.5e-07)
+    npt.assert_allclose(cmp_Ts_idx, ref_Ts_idx, atol=1.5e-07)
+    npt.assert_allclose(cmp_subseq_idx, ref_subseq_idx, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -110,13 +110,13 @@ def test_deterministic_gpu_ostinato_with_isconstant(seed):
         ref_radius, ref_Ts_idx, ref_subseq_idx = naive.ostinato(
             Ts, m, Ts_subseq_isconstant=Ts_subseq_isconstant
         )
-        comp_radius, comp_Ts_idx, comp_subseq_idx = gpu_ostinato(
+        cmp_radius, cmp_Ts_idx, cmp_subseq_idx = gpu_ostinato(
             Ts, m, Ts_subseq_isconstant=Ts_subseq_isconstant
         )
 
-        npt.assert_almost_equal(ref_radius, comp_radius)
-        npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-        npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+        npt.assert_allclose(cmp_radius, ref_radius, atol=1.5e-07)
+        npt.assert_allclose(cmp_Ts_idx, ref_Ts_idx, atol=1.5e-07)
+        npt.assert_allclose(cmp_subseq_idx, ref_subseq_idx, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -135,8 +135,10 @@ def test_input_not_overwritten():
     gpu_ostinato(Ts_input, m)
     for i in range(len(Ts)):
         T_ref = Ts[i]
-        T_comp = Ts_input[i]
-        npt.assert_almost_equal(T_ref[np.isfinite(T_ref)], T_comp[np.isfinite(T_comp)])
+        T_cmp = Ts_input[i]
+        npt.assert_allclose(
+            T_cmp[np.isfinite(T_cmp)], T_ref[np.isfinite(T_ref)], atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -146,27 +148,29 @@ def test_extract_several_consensus():
     # does not tamper with the original data.
     Ts = [rng.RNG.rand(n) for n in [64, 128]]
     Ts_ref = [T.copy() for T in Ts]
-    Ts_comp = [T.copy() for T in Ts]
+    Ts_cmp = [T.copy() for T in Ts]
 
     m = 20
 
     k = 2  # Get the first `k` consensus motifs
     for _ in range(k):
-        # Find consensus motif and its NN in each time series in Ts_comp
-        # Remove them from Ts_comp as well as Ts_ref, and assert that the
+        # Find consensus motif and its NN in each time series in Ts_cmp
+        # Remove them from Ts_cmp as well as Ts_ref, and assert that the
         # two time series are the same
-        radius, Ts_idx, subseq_idx = gpu_ostinato(Ts_comp, m)
-        consensus_motif = Ts_comp[Ts_idx][subseq_idx : subseq_idx + m].copy()
-        for i in range(len(Ts_comp)):
+        radius, Ts_idx, subseq_idx = gpu_ostinato(Ts_cmp, m)
+        consensus_motif = Ts_cmp[Ts_idx][subseq_idx : subseq_idx + m].copy()
+        for i in range(len(Ts_cmp)):
             if i == Ts_idx:
                 query_idx = subseq_idx
             else:
                 query_idx = None
 
-            idx = np.argmin(core.mass(consensus_motif, Ts_comp[i], query_idx=query_idx))
-            Ts_comp[i][idx : idx + m] = np.nan
+            idx = np.argmin(core.mass(consensus_motif, Ts_cmp[i], query_idx=query_idx))
+            Ts_cmp[i][idx : idx + m] = np.nan
             Ts_ref[i][idx : idx + m] = np.nan
 
-            npt.assert_almost_equal(
-                Ts_ref[i][np.isfinite(Ts_ref[i])], Ts_comp[i][np.isfinite(Ts_comp[i])]
+            npt.assert_allclose(
+                Ts_cmp[i][np.isfinite(Ts_cmp[i])],
+                Ts_ref[i][np.isfinite(Ts_ref[i])],
+                atol=1.5e-07,
             )


### PR DESCRIPTION
Related to #1175

Covers `tests/test_gpu_ostinato.py` (14 call sites) — the GPU counterpart to `test_gpu_aamp_ostinato.py`/`test_ostinato.py`, same structure. Renamed `comp_*` to `cmp_*`, flipped every call to `(cmp, ref)` order.

Same as the CPU/aamp GPU versions: radius, indices, and time series are all clean `float64`/`int64` on both sides, no casting needed.

Only runs under CUDA — locally it's a module-level skip, verified with `NUMBA_ENABLE_CUDASIM=1`: 41/41 passing.

## To Do List

- [x] `assert_almost_equal` -> `assert_allclose`
- [x] no `rtol=0`
- [x] `actual, desired` order
- [x] `atol=1.5e-07`
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp_` naming, no casting needed

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Please do not commit any code to avoid/circumvent a failing test and, instead, engage in a discussion (below) to determine the best course of action.

Only request a review **after** the checklist above is fully completed!
