### PR TITLE
Migrate tests/test_gpu_stimp.py to npt.assert_allclose

### DIFF
--- a/tests/test_gpu_stimp.py
+++ b/tests/test_gpu_stimp.py
@@ -65,7 +65,7 @@ def test_gpu_stimp(T):
     naive.replace_inf(ref_PAN)
     naive.replace_inf(cmp_PAN)
 
-    npt.assert_almost_equal(ref_PAN, cmp_PAN)
+    npt.assert_allclose(cmp_PAN, ref_PAN, atol=1.5e-07)
 
     # Compare transformed pan
     cmp_pan = pan.PAN_
@@ -76,7 +76,7 @@ def test_gpu_stimp(T):
     naive.replace_inf(ref_pan)
     naive.replace_inf(cmp_pan)
 
-    npt.assert_almost_equal(ref_pan, cmp_pan)
+    npt.assert_allclose(cmp_pan, ref_pan, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -122,7 +122,7 @@ def test_gpu_stimp_with_isconstant():
     naive.replace_inf(ref_PAN)
     naive.replace_inf(cmp_PAN)
 
-    npt.assert_almost_equal(ref_PAN, cmp_PAN)
+    npt.assert_allclose(cmp_PAN, ref_PAN, atol=1.5e-07)
 
     # Compare transformed pan
     cmp_pan = pan.PAN_
@@ -133,4 +133,4 @@ def test_gpu_stimp_with_isconstant():
     naive.replace_inf(ref_pan)
     naive.replace_inf(cmp_pan)
 
-    npt.assert_almost_equal(ref_pan, cmp_pan)
+    npt.assert_allclose(cmp_pan, ref_pan, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

`tests/test_gpu_stimp.py` (4 sites). Flipped to `(cmp, ref)` order, `atol=1.5e-07`. Both sides are clean float64, no casting needed.

Only runs under CUDA, verified locally with `NUMBA_ENABLE_CUDASIM=1`: 3/3 passing.

## To Do List

- [x] `assert_allclose`, `cmp` first
- [x] `atol=1.5e-07`
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp_` naming

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Only request a review **after** the checklist above is fully completed!
