### PR TITLE
Migrate tests/test_gpu_stump.py to npt.assert_allclose

### DIFF
--- a/tests/test_gpu_stump.py
+++ b/tests/test_gpu_stump.py
@@ -57,14 +57,18 @@ def test_gpu_stump_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
     ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
-    comp_mp = gpu_stump(T_B, m, ignore_trivial=True)
+    cmp_mp = gpu_stump(T_B, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp, comp_mp)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+    )
 
-    comp_mp = gpu_stump(pd.Series(T_B), m, ignore_trivial=True)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp, comp_mp)
+    cmp_mp = gpu_stump(pd.Series(T_B), m, ignore_trivial=True)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+    )
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -75,19 +79,21 @@ def test_gpu_stump_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
         ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
-        comp_mp = gpu_stump(T_B, m, ignore_trivial=True)
+        cmp_mp = gpu_stump(T_B, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
+        naive.replace_inf(cmp_mp)
 
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
-        # comp_mp = gpu_stump(
+        # cmp_mp = gpu_stump(
         #     pd.Series(T_B),
         #     m,
         #     ignore_trivial=True,
         # )
-        # naive.replace_inf(comp_mp)
-        # npt.assert_almost_equal(ref_mp, comp_mp)
+        # naive.replace_inf(cmp_mp)
+        # npt.assert_allclose(cmp_mp, ref_mp, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -96,14 +102,16 @@ def test_gpu_stump_self_join_larger_window(T_A, T_B, m):
 def test_gpu_stump_A_B_join(T_A, T_B):
     m = 3
     ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
-    comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
+    cmp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp, comp_mp)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+    )
 
-    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(ref_mp, comp_mp)
+    # cmp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(cmp_mp, ref_mp, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -115,24 +123,26 @@ def test_parallel_gpu_stump_self_join(T_A, T_B):
         m = 3
         zone = int(np.ceil(m / 4))
         ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
-        comp_mp = gpu_stump(
+        cmp_mp = gpu_stump(
             T_B,
             m,
             ignore_trivial=True,
             device_id=device_ids,
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
-        # comp_mp = gpu_stump(
+        # cmp_mp = gpu_stump(
         #     pd.Series(T_B),
         #     m,
         #     ignore_trivial=True,
         #     device_id=device_ids,
         # )
-        # naive.replace_inf(comp_mp)
-        # npt.assert_almost_equal(ref_mp, comp_mp)
+        # naive.replace_inf(cmp_mp)
+        # npt.assert_allclose(cmp_mp, ref_mp, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -143,7 +153,7 @@ def test_parallel_gpu_stump_A_B_join(T_A, T_B):
     if len(T_B) > 10:
         m = 3
         ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
-        comp_mp = gpu_stump(
+        cmp_mp = gpu_stump(
             T_B,
             m,
             T_A,
@@ -151,18 +161,20 @@ def test_parallel_gpu_stump_A_B_join(T_A, T_B):
             device_id=device_ids,
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
-        # comp_mp = gpu_stump(
+        # cmp_mp = gpu_stump(
         #     pd.Series(T_B),
         #     m,
         #     pd.Series(T_A),
         #     ignore_trivial=False,
         #     device_id=device_ids,
         # )
-        # naive.replace_inf(comp_mp)
-        # npt.assert_almost_equal(ref_mp, comp_mp)
+        # naive.replace_inf(cmp_mp)
+        # npt.assert_allclose(cmp_mp, ref_mp, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -172,14 +184,16 @@ def test_gpu_stump_constant_subsequence_self_join():
     m = 3
     zone = int(np.ceil(m / 4))
     ref_mp = naive.stump(T_A, m, exclusion_zone=zone, row_wise=True)
-    comp_mp = gpu_stump(T_A, m, ignore_trivial=True)
+    cmp_mp = gpu_stump(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
-    # comp_mp = gpu_stump(pd.Series(T_A), m, ignore_trivial=True)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    # cmp_mp = gpu_stump(pd.Series(T_A), m, ignore_trivial=True)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(cmp_mp[:, 0], ref_mp[:, 0], atol=1.5e-07)  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -189,25 +203,29 @@ def test_gpu_stump_one_constant_subsequence_A_B_join():
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
-    comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
+    cmp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
-    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    # cmp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(cmp_mp[:, 0], ref_mp[:, 0], atol=1.5e-07)  # ignore indices
 
     # Swap inputs
     ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
-    comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
+    cmp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
-    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    # cmp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(cmp_mp[:, 0], ref_mp[:, 0], atol=1.5e-07)  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -217,25 +235,29 @@ def test_gpu_stump_two_constant_subsequences_A_B_join():
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
-    comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
+    cmp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
-    # comp_mp = gpu_stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    # cmp_mp = gpu_stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(cmp_mp[:, 0], ref_mp[:, 0], atol=1.5e-07)  # ignore indices
 
     # Swap inputs
     ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
-    comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
+    cmp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp[:, 0].astype(np.float64), ref_mp[:, 0].astype(np.float64), atol=1.5e-07
+    )  # ignore indices
 
-    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
+    # cmp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(cmp_mp[:, 0], ref_mp[:, 0], atol=1.5e-07)  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -248,17 +270,19 @@ def test_gpu_stump_identical_subsequence_self_join():
     m = 3
     zone = int(np.ceil(m / 4))
     ref_mp = naive.stump(T_A, m, exclusion_zone=zone, row_wise=True)
-    comp_mp = gpu_stump(T_A, m, ignore_trivial=True)
+    cmp_mp = gpu_stump(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(
-        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp[:, 0].astype(np.float64),
+        ref_mp[:, 0].astype(np.float64),
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
-    # comp_mp = gpu_stump(pd.Series(T_A), m, ignore_trivial=True)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(
-    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    # cmp_mp = gpu_stump(pd.Series(T_A), m, ignore_trivial=True)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(
+    #     cmp_mp[:, 0], ref_mp[:, 0], atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
 
@@ -272,32 +296,36 @@ def test_gpu_stump_identical_subsequence_A_B_join():
     T_B[11 : 11 + identical.shape[0]] = identical
     m = 3
     ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
-    comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
+    cmp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(
-        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp[:, 0].astype(np.float64),
+        ref_mp[:, 0].astype(np.float64),
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
-    # comp_mp = gpu_stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(
-    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    # cmp_mp = gpu_stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(
+    #     cmp_mp[:, 0], ref_mp[:, 0], atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
     # Swap inputs
     ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
-    comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
+    cmp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(
-        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp[:, 0].astype(np.float64),
+        ref_mp[:, 0].astype(np.float64),
+        atol=1.5 * 10**-config.STUMPY_TEST_PRECISION,
     )  # ignore indices
 
-    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(comp_mp)
-    # npt.assert_almost_equal(
-    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    # cmp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(cmp_mp)
+    # npt.assert_allclose(
+    #     cmp_mp[:, 0], ref_mp[:, 0], atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
 
@@ -317,14 +345,16 @@ def test_gpu_stump_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locati
 
         zone = int(np.ceil(m / 4))
         ref_mp = naive.stump(T_B_sub, m, exclusion_zone=zone, row_wise=True)
-        comp_mp = gpu_stump(T_B_sub, m, ignore_trivial=True)
+        cmp_mp = gpu_stump(T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
-        # comp_mp = gpu_stump(pd.Series(T_B_sub), m, ignore_trivial=True)
-        # naive.replace_inf(comp_mp)
-        # npt.assert_almost_equal(ref_mp, comp_mp)
+        # cmp_mp = gpu_stump(pd.Series(T_B_sub), m, ignore_trivial=True)
+        # naive.replace_inf(cmp_mp)
+        # npt.assert_allclose(cmp_mp, ref_mp, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -349,16 +379,18 @@ def test_gpu_stump_nan_inf_A_B_join(
             T_B_sub[substitution_location_B] = substitute_B
 
             ref_mp = naive.stump(T_B_sub, m, T_B=T_A_sub, row_wise=True)
-            comp_mp = gpu_stump(T_B_sub, m, T_A_sub, ignore_trivial=False)
+            cmp_mp = gpu_stump(T_B_sub, m, T_A_sub, ignore_trivial=False)
             naive.replace_inf(ref_mp)
-            naive.replace_inf(comp_mp)
-            npt.assert_almost_equal(ref_mp, comp_mp)
+            naive.replace_inf(cmp_mp)
+            npt.assert_allclose(
+                cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+            )
 
-            # comp_mp = gpu_stump(
+            # cmp_mp = gpu_stump(
             #     pd.Series(T_B_sub), m, pd.Series(T_A_sub), ignore_trivial=False
             # )
-            # naive.replace_inf(comp_mp)
-            # npt.assert_almost_equal(ref_mp, comp_mp)
+            # naive.replace_inf(cmp_mp)
+            # npt.assert_allclose(cmp_mp, ref_mp, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -369,11 +401,13 @@ def test_gpu_stump_nan_zero_mean_self_join():
 
     zone = int(np.ceil(m / 4))
     ref_mp = naive.stump(T, m, exclusion_zone=zone, row_wise=True)
-    comp_mp = gpu_stump(T, m, ignore_trivial=True)
+    cmp_mp = gpu_stump(T, m, ignore_trivial=True)
 
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(ref_mp, comp_mp)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+    )
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -384,14 +418,18 @@ def test_gpu_stump_self_join_KNN(T_A, T_B):
     zone = int(np.ceil(m / 4))
     for k in range(2, 4):
         ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True, k=k)
-        comp_mp = gpu_stump(T_B, m, ignore_trivial=True, k=k)
+        cmp_mp = gpu_stump(T_B, m, ignore_trivial=True, k=k)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
-        comp_mp = gpu_stump(pd.Series(T_B), m, ignore_trivial=True, k=k)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        cmp_mp = gpu_stump(pd.Series(T_B), m, ignore_trivial=True, k=k)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -401,10 +439,12 @@ def test_gpu_stump_A_B_join_KNN(T_A, T_B):
     m = 3
     for k in range(2, 4):
         ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True, k=k)
-        comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False, k=k)
+        cmp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False, k=k)
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
@@ -428,7 +468,7 @@ def test_gpu_stump_self_join_custom_isconstant(T_A, T_B):
             k=k,
             T_A_subseq_isconstant=T_B_subseq_isconstant,
         )
-        comp_mp = gpu_stump(
+        cmp_mp = gpu_stump(
             T_A=T_B,
             m=m,
             ignore_trivial=True,
@@ -436,8 +476,10 @@ def test_gpu_stump_self_join_custom_isconstant(T_A, T_B):
             T_A_subseq_isconstant=T_B_subseq_isconstant,
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )
 
     # case 2: custom isconstant is func
     for k in range(2, 4):
@@ -449,7 +491,7 @@ def test_gpu_stump_self_join_custom_isconstant(T_A, T_B):
             k=k,
             T_A_subseq_isconstant=isconstant_custom_func,
         )
-        comp_mp = gpu_stump(
+        cmp_mp = gpu_stump(
             T_A=T_B,
             m=m,
             ignore_trivial=True,
@@ -457,5 +499,7 @@ def test_gpu_stump_self_join_custom_isconstant(T_A, T_B):
             T_A_subseq_isconstant=isconstant_custom_func,
         )
         naive.replace_inf(ref_mp)
-        naive.replace_inf(comp_mp)
-        npt.assert_almost_equal(ref_mp, comp_mp)
+        naive.replace_inf(cmp_mp)
+        npt.assert_allclose(
+            cmp_mp.astype(np.float64), ref_mp.astype(np.float64), atol=1.5e-07
+        )


### PR DESCRIPTION
Related to #1175

`tests/test_gpu_stump.py` (36 sites) — same shape as `test_gpu_aamp.py`. Renamed `comp_mp` to `cmp_mp`, flipped order, cast to `float64` since `naive.stump()` mixes distance/index columns (`dtype=object`), same root cause as the earlier files. A few sites keep the `config.STUMPY_TEST_PRECISION` reference instead of the `1.5e-07` literal. Commented-out `pd.Series` variants updated too, left commented.

Only runs under CUDA, verified locally with `NUMBA_ENABLE_CUDASIM=1`: 39/39 passing.

## To Do List

- [x] `assert_allclose`, `cmp` first
- [x] `atol=1.5e-07` / config reference where it was
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp_` naming, cast where needed

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Only request a review **after** the checklist above is fully completed!
