### PR TITLE
Migrate tests/test_maamped.py to npt.assert_allclose

### DIFF
--- a/tests/test_maamped.py
+++ b/tests/test_maamped.py
@@ -46,10 +46,10 @@ def test_maamped(T, m, dask_cluster):
         excl_zone = int(np.ceil(m / 4))
 
         ref_P, ref_I = naive.maamp(T, m, excl_zone)
-        comp_P, comp_I = maamped(dask_client, T, m)
+        cmp_P, cmp_I = maamped(dask_client, T, m)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -63,10 +63,10 @@ def test_maamped_include(T, m, dask_cluster):
                 excl_zone = int(np.ceil(m / 4))
 
                 ref_P, ref_I = naive.maamp(T, m, excl_zone, include)
-                comp_P, comp_I = maamped(dask_client, T, m, include)
+                cmp_P, cmp_I = maamped(dask_client, T, m, include)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -76,10 +76,10 @@ def test_maamped_discords(T, m, dask_cluster):
         excl_zone = int(np.ceil(m / 4))
 
         ref_P, ref_I = naive.maamp(T, m, excl_zone, discords=True)
-        comp_P, comp_I = maamped(dask_client, T, m, discords=True)
+        cmp_P, cmp_I = maamped(dask_client, T, m, discords=True)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -93,10 +93,10 @@ def test_maamped_include_discords(T, m, dask_cluster):
                 excl_zone = int(np.ceil(m / 4))
 
                 ref_P, ref_I = naive.maamp(T, m, excl_zone, include, discords=True)
-                comp_P, comp_I = maamped(dask_client, T, m, include, discords=True)
+                cmp_P, cmp_I = maamped(dask_client, T, m, include, discords=True)
 
-                npt.assert_almost_equal(ref_P, comp_P)
-                npt.assert_almost_equal(ref_I, comp_I)
+                npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+                npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -107,10 +107,10 @@ def test_maamped_df(T, m, dask_cluster):
 
         ref_P, ref_I = naive.maamp(T, m, excl_zone)
         df = pd.DataFrame(T.T)
-        comp_P, comp_I = maamped(dask_client, df, m)
+        cmp_P, cmp_I = maamped(dask_client, df, m)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -125,9 +125,9 @@ def test_maamped_constant_subsequence_self_join(dask_cluster):
         excl_zone = int(np.ceil(m / 4))
 
         ref_P, ref_I = naive.maamp(T, m, excl_zone)
-        comp_P, comp_I = maamped(dask_client, T, m)
+        cmp_P, cmp_I = maamped(dask_client, T, m)
 
-        npt.assert_almost_equal(ref_P, comp_P)  # ignore indices
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -143,10 +143,10 @@ def test_maamped_identical_subsequence_self_join(dask_cluster):
         excl_zone = int(np.ceil(m / 4))
 
         ref_P, ref_I = naive.maamp(T, m, excl_zone)
-        comp_P, comp_I = maamped(dask_client, T, m)
+        cmp_P, cmp_I = maamped(dask_client, T, m)
 
-        npt.assert_almost_equal(
-            ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION
+        npt.assert_allclose(
+            cmp_P, ref_P, atol=1.5 * 10**-config.STUMPY_TEST_PRECISION
         )  # ignore indices
 
 
@@ -163,10 +163,10 @@ def test_maamped_one_subsequence_inf_self_join_first_dimension(
         T_sub[0, substitution_location] = np.inf
 
         ref_P, ref_I = naive.maamp(T_sub, m, excl_zone)
-        comp_P, comp_I = maamped(dask_client, T_sub, m)
+        cmp_P, cmp_I = maamped(dask_client, T_sub, m)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -182,10 +182,10 @@ def test_maamped_one_subsequence_inf_self_join_all_dimensions(
         T_sub[:, substitution_location] = np.inf
 
         ref_P, ref_I = naive.maamp(T_sub, m, excl_zone)
-        comp_P, comp_I = maamped(dask_client, T_sub, m)
+        cmp_P, cmp_I = maamped(dask_client, T_sub, m)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -201,10 +201,10 @@ def test_maamped_one_subsequence_nan_self_join_first_dimension(
         T_sub[0, substitution_location] = np.nan
 
         ref_P, ref_I = naive.maamp(T_sub, m, excl_zone)
-        comp_P, comp_I = maamped(dask_client, T_sub, m)
+        cmp_P, cmp_I = maamped(dask_client, T_sub, m)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -220,7 +220,7 @@ def test_maamped_one_subsequence_nan_self_join_all_dimensions(
         T_sub[:, substitution_location] = np.nan
 
         ref_P, ref_I = naive.maamp(T_sub, m, excl_zone)
-        comp_P, comp_I = maamped(dask_client, T_sub, m)
+        cmp_P, cmp_I = maamped(dask_client, T_sub, m)
 
-        npt.assert_almost_equal(ref_P, comp_P)
-        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_allclose(cmp_P, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp_I, ref_I, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

`tests/test_maamped.py` (20 sites) — the dask-parallel counterpart to `test_maamp.py`. Renamed `comp` to `cmp`, flipped order. `maamped()` returns clean `float64`/`int64` (P, I) just like the CPU version, so no casting needed anywhere. One site keeps the `config.STUMPY_TEST_PRECISION` reference.

53/53 passing locally in both normal and CI-equivalent modes.

## To Do List

- [x] `assert_allclose`, `cmp` first
- [x] `atol=1.5e-07` / config reference where it was
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp_` naming, no casting needed

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Only request a review **after** the checklist above is fully completed!
