### PR TITLE
Migrate tests/test_mmparray.py to npt.assert_allclose

### DIFF
--- a/tests/test_mmparray.py
+++ b/tests/test_mmparray.py
@@ -18,10 +18,10 @@ def test_mmparray_mstump(T, m):
     excl_zone = int(np.ceil(m / 4))
 
     ref_P, ref_I = naive.mstump(T, m, excl_zone)
-    comp = mstump(T, m)
+    cmp = mstump(T, m)
 
-    npt.assert_almost_equal(ref_P, comp.P_)
-    npt.assert_almost_equal(ref_I, comp.I_)
+    npt.assert_allclose(cmp.P_, ref_P, atol=1.5e-07)
+    npt.assert_allclose(cmp.I_, ref_I, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T, m", test_data)
@@ -30,7 +30,7 @@ def test_mmparray_maamp(T, m):
 
     for p in [1.0, 2.0, 3.0]:
         ref_P, ref_I = naive.maamp(T, m, excl_zone, p=p)
-        comp = maamp(T, m, p=p)
+        cmp = maamp(T, m, p=p)
 
-        npt.assert_almost_equal(ref_P, comp.P_)
-        npt.assert_almost_equal(ref_I, comp.I_)
+        npt.assert_allclose(cmp.P_, ref_P, atol=1.5e-07)
+        npt.assert_allclose(cmp.I_, ref_I, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

`tests/test_mmparray.py` (4 sites, small one). Renamed `comp` to `cmp`, flipped order to `(cmp.P_/I_, ref)`, `atol=1.5e-07`. Both sides are clean float64/int64, no casting needed.

4/4 passing locally in both modes.

## To Do List

- [x] `assert_allclose`, `cmp` first
- [x] `atol=1.5e-07`
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp` naming, no casting needed

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Only request a review **after** the checklist above is fully completed!
