### PR TITLE
Migrate tests/test_mparray.py to npt.assert_allclose

### DIFF
--- a/tests/test_mparray.py
+++ b/tests/test_mparray.py
@@ -47,36 +47,100 @@ def test_mparray_self_join(T_A, T_B, k):
     zone = int(np.ceil(m / 4))
 
     ref_mp = naive.stump(T_B, m, exclusion_zone=zone, k=k)
-    comp_mp = stump(T_B, m, ignore_trivial=True, k=k)
+    cmp_mp = stump(T_B, m, ignore_trivial=True, k=k)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, :k]), comp_mp.P_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, k : 2 * k]), comp_mp.I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k]), comp_mp.left_I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k + 1]), comp_mp.right_I_)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.P_.astype(np.float64),
+        np.squeeze(ref_mp[:, :k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.I_.astype(np.float64),
+        np.squeeze(ref_mp[:, k : 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.left_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.right_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k + 1]).astype(np.float64),
+        atol=1.5e-07,
+    )
 
-    comp_mp = stump(pd.Series(T_B), m, ignore_trivial=True, k=k)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, :k]), comp_mp.P_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, k : 2 * k]), comp_mp.I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k]), comp_mp.left_I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k + 1]), comp_mp.right_I_)
+    cmp_mp = stump(pd.Series(T_B), m, ignore_trivial=True, k=k)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.P_.astype(np.float64),
+        np.squeeze(ref_mp[:, :k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.I_.astype(np.float64),
+        np.squeeze(ref_mp[:, k : 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.left_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.right_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k + 1]).astype(np.float64),
+        atol=1.5e-07,
+    )
 
     ref_mp = naive.aamp(T_B, m, exclusion_zone=zone, k=k)
-    comp_mp = aamp(T_B, m, ignore_trivial=True, k=k)
+    cmp_mp = aamp(T_B, m, ignore_trivial=True, k=k)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, :k]), comp_mp.P_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, k : 2 * k]), comp_mp.I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k]), comp_mp.left_I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k + 1]), comp_mp.right_I_)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.P_.astype(np.float64),
+        np.squeeze(ref_mp[:, :k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.I_.astype(np.float64),
+        np.squeeze(ref_mp[:, k : 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.left_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.right_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k + 1]).astype(np.float64),
+        atol=1.5e-07,
+    )
 
-    comp_mp = aamp(pd.Series(T_B), m, ignore_trivial=True, k=k)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, :k]), comp_mp.P_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, k : 2 * k]), comp_mp.I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k]), comp_mp.left_I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k + 1]), comp_mp.right_I_)
+    cmp_mp = aamp(pd.Series(T_B), m, ignore_trivial=True, k=k)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.P_.astype(np.float64),
+        np.squeeze(ref_mp[:, :k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.I_.astype(np.float64),
+        np.squeeze(ref_mp[:, k : 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.left_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.right_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k + 1]).astype(np.float64),
+        atol=1.5e-07,
+    )
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -84,33 +148,97 @@ def test_mparray_self_join(T_A, T_B, k):
 def test_mparray_A_B_join(T_A, T_B, k):
     m = 3
     ref_mp = naive.stump(T_A, m, T_B=T_B, k=k)
-    comp_mp = stump(T_A, m, T_B, ignore_trivial=False, k=k)
+    cmp_mp = stump(T_A, m, T_B, ignore_trivial=False, k=k)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, :k]), comp_mp.P_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, k : 2 * k]), comp_mp.I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k]), comp_mp.left_I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k + 1]), comp_mp.right_I_)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.P_.astype(np.float64),
+        np.squeeze(ref_mp[:, :k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.I_.astype(np.float64),
+        np.squeeze(ref_mp[:, k : 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.left_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.right_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k + 1]).astype(np.float64),
+        atol=1.5e-07,
+    )
 
-    comp_mp = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, k=k)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, :k]), comp_mp.P_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, k : 2 * k]), comp_mp.I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k]), comp_mp.left_I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k + 1]), comp_mp.right_I_)
+    cmp_mp = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, k=k)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.P_.astype(np.float64),
+        np.squeeze(ref_mp[:, :k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.I_.astype(np.float64),
+        np.squeeze(ref_mp[:, k : 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.left_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.right_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k + 1]).astype(np.float64),
+        atol=1.5e-07,
+    )
 
     ref_mp = naive.aamp(T_A, m, T_B=T_B, k=k)
-    comp_mp = aamp(T_A, m, T_B, ignore_trivial=False, k=k)
+    cmp_mp = aamp(T_A, m, T_B, ignore_trivial=False, k=k)
     naive.replace_inf(ref_mp)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, :k]), comp_mp.P_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, k : 2 * k]), comp_mp.I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k]), comp_mp.left_I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k + 1]), comp_mp.right_I_)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.P_.astype(np.float64),
+        np.squeeze(ref_mp[:, :k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.I_.astype(np.float64),
+        np.squeeze(ref_mp[:, k : 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.left_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.right_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k + 1]).astype(np.float64),
+        atol=1.5e-07,
+    )
 
-    comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, k=k)
-    naive.replace_inf(comp_mp)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, :k]), comp_mp.P_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, k : 2 * k]), comp_mp.I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k]), comp_mp.left_I_)
-    npt.assert_almost_equal(np.squeeze(ref_mp[:, 2 * k + 1]), comp_mp.right_I_)
+    cmp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False, k=k)
+    naive.replace_inf(cmp_mp)
+    npt.assert_allclose(
+        cmp_mp.P_.astype(np.float64),
+        np.squeeze(ref_mp[:, :k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.I_.astype(np.float64),
+        np.squeeze(ref_mp[:, k : 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.left_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k]).astype(np.float64),
+        atol=1.5e-07,
+    )
+    npt.assert_allclose(
+        cmp_mp.right_I_.astype(np.float64),
+        np.squeeze(ref_mp[:, 2 * k + 1]).astype(np.float64),
+        atol=1.5e-07,
+    )


### PR DESCRIPTION
Related to #1175

`tests/test_mparray.py` (32 sites, dense — 4 comparisons per `mparray` field repeated 8 times). Renamed `comp_mp` to `cmp_mp`, flipped order.

Every site compares `cmp_mp.P_`/`.I_`/`.left_I_`/`.right_I_` (clean float64/int64) against a column slice of `naive.stump()`/`naive.aamp()`, which stays `dtype=object` even after slicing (same root cause as the earlier files) — cast both sides on all 32.

18/18 passing locally in both modes.

## To Do List

- [x] `assert_allclose`, `cmp` first
- [x] `atol=1.5e-07`
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp_` naming, cast on all sites since the ref side is `dtype=object`

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Only request a review **after** the checklist above is fully completed!
