### PR TITLE
Migrate tests/test_mpdist.py to npt.assert_allclose

### DIFF
--- a/tests/test_mpdist.py
+++ b/tests/test_mpdist.py
@@ -50,11 +50,11 @@ def test_mpdist_vect(T_A, T_B):
     T_subseq_isconstant = naive.rolling_isconstant(T_B, m)
     μ_Q, σ_Q = naive.compute_mean_std(T_A, m)
     M_T, Σ_T = naive.compute_mean_std(T_B, m)
-    comp_mpdist_vect = _mpdist_vect(
+    cmp_mpdist_vect = _mpdist_vect(
         T_A, T_B, m, μ_Q, σ_Q, M_T, Σ_T, Q_subseq_isconstant, T_subseq_isconstant
     )
 
-    npt.assert_almost_equal(ref_mpdist_vect, comp_mpdist_vect)
+    npt.assert_allclose(cmp_mpdist_vect, ref_mpdist_vect, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -67,7 +67,7 @@ def test_mpdist_vect_percentage(T_A, T_B, percentage):
     T_subseq_isconstant = naive.rolling_isconstant(T_B, m)
     μ_Q, σ_Q = naive.compute_mean_std(T_A, m)
     M_T, Σ_T = naive.compute_mean_std(T_B, m)
-    comp_mpdist_vect = _mpdist_vect(
+    cmp_mpdist_vect = _mpdist_vect(
         T_A,
         T_B,
         m,
@@ -80,7 +80,7 @@ def test_mpdist_vect_percentage(T_A, T_B, percentage):
         percentage=percentage,
     )
 
-    npt.assert_almost_equal(ref_mpdist_vect, comp_mpdist_vect)
+    npt.assert_allclose(cmp_mpdist_vect, ref_mpdist_vect, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -93,20 +93,20 @@ def test_mpdist_vect_k(T_A, T_B, k):
     T_subseq_isconstant = naive.rolling_isconstant(T_B, m)
     μ_Q, σ_Q = naive.compute_mean_std(T_A, m)
     M_T, Σ_T = naive.compute_mean_std(T_B, m)
-    comp_mpdist_vect = _mpdist_vect(
+    cmp_mpdist_vect = _mpdist_vect(
         T_A, T_B, m, μ_Q, σ_Q, M_T, Σ_T, Q_subseq_isconstant, T_subseq_isconstant, k=k
     )
 
-    npt.assert_almost_equal(ref_mpdist_vect, comp_mpdist_vect)
+    npt.assert_allclose(cmp_mpdist_vect, ref_mpdist_vect, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_mpdist(T_A, T_B):
     m = 3
     ref_mpdist = naive.mpdist(T_A, T_B, m)
-    comp_mpdist = mpdist(T_A, T_B, m)
+    cmp_mpdist = mpdist(T_A, T_B, m)
 
-    npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+    npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -125,7 +125,7 @@ def test_mpdist_with_isconstant(T_A, T_B):
         T_A_subseq_isconstant=T_A_subseq_isconstant,
         T_B_subseq_isconstant=T_B_subseq_isconstant,
     )
-    comp_mpdist = mpdist(
+    cmp_mpdist = mpdist(
         T_A,
         T_B,
         m,
@@ -133,7 +133,7 @@ def test_mpdist_with_isconstant(T_A, T_B):
         T_B_subseq_isconstant=T_B_subseq_isconstant,
     )
 
-    npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+    npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -141,9 +141,9 @@ def test_mpdist_with_isconstant(T_A, T_B):
 def test_mpdist_percentage(T_A, T_B, percentage):
     m = 3
     ref_mpdist = naive.mpdist(T_A, T_B, m, percentage=percentage)
-    comp_mpdist = mpdist(T_A, T_B, m, percentage=percentage)
+    cmp_mpdist = mpdist(T_A, T_B, m, percentage=percentage)
 
-    npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+    npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -151,9 +151,9 @@ def test_mpdist_percentage(T_A, T_B, percentage):
 def test_mpdist_k(T_A, T_B, k):
     m = 3
     ref_mpdist = naive.mpdist(T_A, T_B, m, k=k)
-    comp_mpdist = mpdist(T_A, T_B, m, k=k)
+    cmp_mpdist = mpdist(T_A, T_B, m, k=k)
 
-    npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+    npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -165,9 +165,9 @@ def test_mpdisted(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
         ref_mpdist = naive.mpdist(T_A, T_B, m)
-        comp_mpdist = mpdisted(dask_client, T_A, T_B, m)
+        cmp_mpdist = mpdisted(dask_client, T_A, T_B, m)
 
-        npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+        npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -191,7 +191,7 @@ def test_mpdisted_with_isconstant(T_A, T_B, dask_cluster):
             T_A_subseq_isconstant=T_A_subseq_isconstant,
             T_B_subseq_isconstant=T_B_subseq_isconstant,
         )
-        comp_mpdist = mpdisted(
+        cmp_mpdist = mpdisted(
             dask_client,
             T_A,
             T_B,
@@ -200,7 +200,7 @@ def test_mpdisted_with_isconstant(T_A, T_B, dask_cluster):
             T_B_subseq_isconstant=T_B_subseq_isconstant,
         )
 
-        npt.assert_almost_equal(ref_mpdist, comp_mpdist)
+        npt.assert_allclose(cmp_mpdist, ref_mpdist, atol=1.5e-07)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -225,8 +225,8 @@ def test_mpdist_vect_with_isconstant(T_A, T_B):
     T_subseq_isconstant = T_B_subseq_isconstant
     μ_Q, σ_Q = naive.compute_mean_std(T_A, m)
     M_T, Σ_T = naive.compute_mean_std(T_B, m)
-    comp_mpdist_vect = _mpdist_vect(
+    cmp_mpdist_vect = _mpdist_vect(
         T_A, T_B, m, μ_Q, σ_Q, M_T, Σ_T, Q_subseq_isconstant, T_subseq_isconstant
     )
 
-    npt.assert_almost_equal(ref_mpdist_vect, comp_mpdist_vect)
+    npt.assert_allclose(cmp_mpdist_vect, ref_mpdist_vect, atol=1.5e-07)


### PR DESCRIPTION
Related to #1175

`tests/test_mpdist.py` (10 sites) — the normalized counterpart to `test_aampdist.py`. Renamed `comp_mpdist`/`comp_mpdist_vect` to `cmp_*`, flipped order, `atol=1.5e-07`. All values are plain float64, no casting needed.

44/44 passing locally in both modes.

## To Do List

- [x] `assert_allclose`, `cmp` first
- [x] `atol=1.5e-07`
- [x] `cmp` not `comp`
- [x] `ref_`/`cmp_` naming, no casting needed

# Pull Request Checklist

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Read and reviewed all of the comments in the Github issue that you've referenced (along with cross-referenced issues/pull requests) to ensure that the issue still requires a pull request
- [x] Checked that the issue has not already been assigned to anybody else or is already being addressed in another pull request
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution and received confirmation from the maintainers before proceeding with this pull request
- [x] Forked, cloned, and checked out the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory and ensured that all tests are passing locally
- [x] Check this box if AI code assistance was used to generate 15%+ of the code in this pull request

Only request a review **after** the checklist above is fully completed!
